### PR TITLE
feat: settings tabs, credential validation, and expiry notifications

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@tailwindcss/vite": "^4.2.1",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-http": "^2.5.7",
+        "@tauri-apps/plugin-notification": "^2.3.3",
         "@tauri-apps/plugin-opener": "^2",
         "@tauri-apps/plugin-store": "^2.4.2",
         "class-variance-authority": "^0.7.1",
@@ -2345,6 +2346,15 @@
       "license": "MIT OR Apache-2.0",
       "dependencies": {
         "@tauri-apps/api": "^2.10.1"
+      }
+    },
+    "node_modules/@tauri-apps/plugin-notification": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-notification/-/plugin-notification-2.3.3.tgz",
+      "integrity": "sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==",
+      "license": "MIT OR Apache-2.0",
+      "dependencies": {
+        "@tauri-apps/api": "^2.8.0"
       }
     },
     "node_modules/@tauri-apps/plugin-opener": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@tailwindcss/vite": "^4.2.1",
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-http": "^2.5.7",
+    "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2",
     "@tauri-apps/plugin-store": "^2.4.2",
     "class-variance-authority": "^0.7.1",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2119,6 +2119,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2266,6 +2278,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "notify-rust"
+version = "4.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21af20a1b50be5ac5861f74af1a863da53a11c38684d9818d82f1c42f7fdc6c2"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2372,6 +2398,7 @@ checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -2749,7 +2776,7 @@ checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.13.0",
- "quick-xml",
+ "quick-xml 0.38.4",
  "serde",
  "time",
 ]
@@ -2903,6 +2930,15 @@ checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
 dependencies = [
  "idna",
  "psl-types",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -4017,6 +4053,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-http",
+ "tauri-plugin-notification",
  "tauri-plugin-opener",
  "tauri-plugin-store",
 ]
@@ -4145,6 +4182,25 @@ dependencies = [
  "tokio",
  "url",
  "urlpattern",
+]
+
+[[package]]
+name = "tauri-plugin-notification"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01fc2c5ff41105bd1f7242d8201fdf3efd70749b82fa013a17f2126357d194cc"
+dependencies = [
+ "log",
+ "notify-rust",
+ "rand 0.9.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -4283,6 +4339,18 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 0.9.12+spec-1.1.0",
+]
+
+[[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml 0.37.5",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-store = "2"
 tauri-plugin-http = { version = "2", features = ["unsafe-headers"] }
+tauri-plugin-notification = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -10,6 +10,7 @@
     "http:default",
     "http:allow-fetch-send",
     "http:allow-fetch-read-body",
+    "notification:default",
     {
       "identifier": "http:allow-fetch",
       "allow": [

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -10,6 +10,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_store::Builder::default().build())
         .plugin(tauri_plugin_http::init())
+        .plugin(tauri_plugin_notification::init())
         .invoke_handler(tauri::generate_handler![greet])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,7 +60,7 @@ export default function App() {
         {page === "dashboard" ? (
           <Dashboard onNavigateToSettings={() => setPage("settings")} />
         ) : (
-          <Settings />
+          <Settings onSaved={() => setPage("dashboard")} />
         )}
       </div>
     </div>

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,0 +1,80 @@
+import { Tabs as TabsPrimitive } from "@base-ui/react/tabs"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+function Tabs({
+  className,
+  orientation = "horizontal",
+  ...props
+}: TabsPrimitive.Root.Props) {
+  return (
+    <TabsPrimitive.Root
+      data-slot="tabs"
+      data-orientation={orientation}
+      className={cn(
+        "group/tabs flex gap-2 data-horizontal:flex-col",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const tabsListVariants = cva(
+  "group/tabs-list inline-flex w-fit items-center justify-center rounded-lg p-[3px] text-muted-foreground group-data-horizontal/tabs:h-8 group-data-vertical/tabs:h-fit group-data-vertical/tabs:flex-col data-[variant=line]:rounded-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-muted",
+        line: "gap-1 bg-transparent",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function TabsList({
+  className,
+  variant = "default",
+  ...props
+}: TabsPrimitive.List.Props & VariantProps<typeof tabsListVariants>) {
+  return (
+    <TabsPrimitive.List
+      data-slot="tabs-list"
+      data-variant={variant}
+      className={cn(tabsListVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function TabsTrigger({ className, ...props }: TabsPrimitive.Tab.Props) {
+  return (
+    <TabsPrimitive.Tab
+      data-slot="tabs-trigger"
+      className={cn(
+        "relative inline-flex h-[calc(100%-1px)] flex-1 items-center justify-center gap-1.5 rounded-md border border-transparent px-1.5 py-0.5 text-sm font-medium whitespace-nowrap text-foreground/60 transition-all group-data-vertical/tabs:w-full group-data-vertical/tabs:justify-start hover:text-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 dark:text-muted-foreground dark:hover:text-foreground group-data-[variant=default]/tabs-list:data-active:shadow-sm group-data-[variant=line]/tabs-list:data-active:shadow-none [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-active:bg-transparent dark:group-data-[variant=line]/tabs-list:data-active:border-transparent dark:group-data-[variant=line]/tabs-list:data-active:bg-transparent",
+        "data-active:bg-background data-active:text-foreground dark:data-active:border-input dark:data-active:bg-input/30 dark:data-active:text-foreground",
+        "after:absolute after:bg-foreground after:opacity-0 after:transition-opacity group-data-horizontal/tabs:after:inset-x-0 group-data-horizontal/tabs:after:bottom-[-5px] group-data-horizontal/tabs:after:h-0.5 group-data-vertical/tabs:after:inset-y-0 group-data-vertical/tabs:after:-right-1 group-data-vertical/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-active:after:opacity-100",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function TabsContent({ className, ...props }: TabsPrimitive.Panel.Props) {
+  return (
+    <TabsPrimitive.Panel
+      data-slot="tabs-content"
+      className={cn("flex-1 text-sm outline-none", className)}
+      {...props}
+    />
+  )
+}
+
+export { Tabs, TabsList, TabsTrigger, TabsContent, tabsListVariants }

--- a/src/lib/notify.ts
+++ b/src/lib/notify.ts
@@ -1,0 +1,40 @@
+import {
+  isPermissionGranted,
+  requestPermission,
+  sendNotification,
+} from "@tauri-apps/plugin-notification";
+
+async function ensurePermission(): Promise<boolean> {
+  let granted = await isPermissionGranted();
+  if (!granted) {
+    const permission = await requestPermission();
+    granted = permission === "granted";
+  }
+  return granted;
+}
+
+export async function notify(title: string, body: string) {
+  const granted = await ensurePermission();
+  if (granted) {
+    sendNotification({ title, body });
+  }
+}
+
+// Decode JWT exp field (no library needed — just base64 decode the payload)
+export function getJwtExpiry(token: string): Date | null {
+  try {
+    const payload = token.split(".")[1];
+    const decoded = JSON.parse(atob(payload.replace(/-/g, "+").replace(/_/g, "/")));
+    if (decoded.exp) return new Date(decoded.exp * 1000);
+  } catch {
+    // not a valid JWT
+  }
+  return null;
+}
+
+// Returns true if token expires within the given minutes
+export function expiresWithin(token: string, minutes: number): boolean {
+  const expiry = getJwtExpiry(token);
+  if (!expiry) return false;
+  return expiry.getTime() - Date.now() < minutes * 60 * 1000;
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -12,6 +12,7 @@ import { loadCredentials } from "@/lib/credentials";
 import { fetchClaudeUsage } from "@/lib/api/claude";
 import { fetchChatGPTUsage } from "@/lib/api/chatgpt";
 import { fetchCursorUsage } from "@/lib/api/cursor";
+import { notify, expiresWithin } from "@/lib/notify";
 import type { ServiceData } from "@/types";
 
 const SERVICE_COLORS: Record<string, string> = {
@@ -217,6 +218,12 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
     setFetchError(null);
     try {
       const creds = await loadCredentials();
+
+      // Warn if ChatGPT JWT expires within 30 minutes
+      if (creds.chatgpt?.bearerToken && expiresWithin(creds.chatgpt.bearerToken, 30)) {
+        notify("uso.ai · ChatGPT token expiring soon", "Your ChatGPT Bearer token expires in less than 30 minutes. Update it in Settings.");
+      }
+
       const results = await Promise.all([
         creds.claude?.orgId && creds.claude?.sessionKey
           ? fetchClaudeUsage(creds.claude.orgId, creds.claude.sessionKey)
@@ -228,6 +235,13 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
           ? fetchCursorUsage(creds.cursor.sessionToken)
           : null,
       ]);
+
+      // Notify for any expired tokens
+      const expired = results.filter((r) => r?.status === "expired");
+      for (const s of expired) {
+        if (s) notify(`uso.ai · ${s.name} token expired`, `Your ${s.name} session token has expired. Update it in Settings.`);
+      }
+
       setServices(results.filter((r): r is ServiceData => r !== null));
       setLastUpdated(new Date());
     } catch (e) {

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,14 +1,18 @@
 import { useState, useEffect } from "react";
 import { Eye, EyeOff, CheckCircle2, Circle } from "lucide-react";
 import { load } from "@tauri-apps/plugin-store";
-import { Card, CardContent, CardHeader } from "@/components/ui/card";
+import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import { Avatar, AvatarImage, AvatarFallback } from "@/components/ui/avatar";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import claudeLogo from "@/assets/claude.png";
 import chatgptLogo from "@/assets/chatgpt.png";
 import cursorLogo from "@/assets/cursor.png";
+import { fetchClaudeUsage } from "@/lib/api/claude";
+import { fetchChatGPTUsage } from "@/lib/api/chatgpt";
+import { fetchCursorUsage } from "@/lib/api/cursor";
 
 const SERVICE_LOGOS: Record<string, string> = {
   claude: claudeLogo,
@@ -27,7 +31,6 @@ type ServiceConfig = {
   id: string;
   name: string;
   color: string;
-  favicon: string;
   fields: FieldConfig[];
 };
 
@@ -36,7 +39,6 @@ const services: ServiceConfig[] = [
     id: "claude",
     name: "Claude",
     color: "#cc785c",
-    favicon: "https://claude.ai/favicon.ico",
     fields: [
       {
         key: "orgId",
@@ -56,7 +58,6 @@ const services: ServiceConfig[] = [
     id: "chatgpt",
     name: "ChatGPT",
     color: "#19c37d",
-    favicon: "https://chatgpt.com/favicon.ico",
     fields: [
       {
         key: "bearerToken",
@@ -70,7 +71,6 @@ const services: ServiceConfig[] = [
     id: "cursor",
     name: "Cursor",
     color: "#6e7bff",
-    favicon: "https://cursor.com/favicon.ico",
     fields: [
       {
         key: "sessionToken",
@@ -84,15 +84,12 @@ const services: ServiceConfig[] = [
 
 type Credentials = Record<string, Record<string, string>>;
 
-function isServiceConfigured(creds: Credentials, service: ServiceConfig): boolean {
+function isConfigured(creds: Credentials, service: ServiceConfig): boolean {
   return service.fields.every((f) => !!creds[service.id]?.[f.key]);
 }
 
 function PasswordInput({
-  id,
-  placeholder,
-  value,
-  onChange,
+  id, placeholder, value, onChange,
 }: {
   id: string;
   placeholder: string;
@@ -121,9 +118,11 @@ function PasswordInput({
   );
 }
 
-export default function Settings() {
+type Props = { onSaved?: () => void };
+
+export default function Settings({ onSaved }: Props) {
   const [credentials, setCredentials] = useState<Credentials>({});
-  const [status, setStatus] = useState<"idle" | "saved" | "error">("idle");
+  const [statuses, setStatuses] = useState<Record<string, "idle" | "saving" | "saved" | "expired" | "error">>({});
 
   useEffect(() => {
     async function loadCreds() {
@@ -143,93 +142,120 @@ export default function Settings() {
       ...prev,
       [serviceId]: { ...prev[serviceId], [fieldKey]: value },
     }));
-    setStatus("idle");
+    setStatuses((prev) => ({ ...prev, [serviceId]: "idle" }));
   }
 
-  async function handleSave() {
+  async function handleSave(serviceId: string) {
+    setStatuses((prev) => ({ ...prev, [serviceId]: "saving" }));
     try {
+      // Validate credentials before saving
+      const creds = credentials[serviceId] ?? {};
+      let validationStatus: string = "ok";
+
+      if (serviceId === "claude" && creds.orgId && creds.sessionKey) {
+        const result = await fetchClaudeUsage(creds.orgId, creds.sessionKey);
+        validationStatus = result.status;
+      } else if (serviceId === "chatgpt" && creds.bearerToken) {
+        const result = await fetchChatGPTUsage(creds.bearerToken);
+        validationStatus = result.status;
+      } else if (serviceId === "cursor" && creds.sessionToken) {
+        const result = await fetchCursorUsage(creds.sessionToken);
+        validationStatus = result.status;
+      }
+
+      if (validationStatus === "expired") {
+        setStatuses((prev) => ({ ...prev, [serviceId]: "expired" }));
+        return;
+      }
+      if (validationStatus === "error") {
+        setStatuses((prev) => ({ ...prev, [serviceId]: "error" }));
+        return;
+      }
+
       const store = await load("credentials.json", { autoSave: false });
       await store.set("credentials", credentials);
       await store.save();
-      setStatus("saved");
-      setTimeout(() => setStatus("idle"), 2000);
+      setStatuses((prev) => ({ ...prev, [serviceId]: "saved" }));
+      setTimeout(() => {
+        setStatuses((prev) => ({ ...prev, [serviceId]: "idle" }));
+        onSaved?.();
+      }, 800);
     } catch (e) {
       console.error("Failed to save credentials", e);
-      setStatus("error");
+      setStatuses((prev) => ({ ...prev, [serviceId]: "error" }));
     }
   }
 
   return (
-    <div className="max-w-lg mx-auto space-y-8">
+    <div className="max-w-lg mx-auto space-y-6">
       <div>
         <h2 className="text-base font-semibold">Credentials</h2>
         <p className="text-xs text-muted-foreground mt-0.5">
-          Session tokens are stored locally on your machine and never leave this app.
+          Session tokens are stored locally and never leave this app.
         </p>
       </div>
 
-      <div className="space-y-4">
-        {services.map((service) => {
-          const configured = isServiceConfigured(credentials, service);
-          return (
-            <Card key={service.id} className="overflow-hidden">
-              {/* Service header strip */}
-              <CardHeader className="pb-0 pt-5 px-6">
-                <div className="flex items-center justify-between mb-5">
-                  <div className="flex items-center gap-2.5">
-                    <Avatar className="w-6 h-6 rounded-md">
-                      <AvatarImage src={SERVICE_LOGOS[service.id]} alt={service.name} className="object-contain p-0.5" />
-                      <AvatarFallback
-                        className="rounded-md text-white text-xs font-bold"
-                        style={{ backgroundColor: service.color }}
-                      >
-                        {service.name[0]}
-                      </AvatarFallback>
-                    </Avatar>
-                    <span className="text-sm font-semibold">{service.name}</span>
-                  </div>
-                  {configured ? (
-                    <div className="flex items-center gap-1 text-xs text-emerald-600">
-                      <CheckCircle2 size={13} />
-                      Configured
-                    </div>
-                  ) : (
-                    <div className="flex items-center gap-1 text-xs text-muted-foreground">
-                      <Circle size={13} />
-                      Not configured
-                    </div>
-                  )}
-                </div>
-              </CardHeader>
+      <Tabs defaultValue="claude">
+        <TabsList className="w-full">
+          {services.map((service) => {
+            const configured = isConfigured(credentials, service);
+            return (
+              <TabsTrigger key={service.id} value={service.id} className="flex-1 gap-2">
+                <Avatar className="w-4 h-4 rounded-sm">
+                  <AvatarImage src={SERVICE_LOGOS[service.id]} alt={service.name} className="object-contain" />
+                  <AvatarFallback className="rounded-sm text-white text-[10px] font-bold" style={{ backgroundColor: service.color }}>
+                    {service.name[0]}
+                  </AvatarFallback>
+                </Avatar>
+                {service.name}
+                {configured
+                  ? <CheckCircle2 size={12} className="text-muted-foreground ml-auto" />
+                  : <Circle size={12} className="text-muted-foreground/40 ml-auto" />
+                }
+              </TabsTrigger>
+            );
+          })}
+        </TabsList>
 
-              <CardContent className="px-6 pb-6 space-y-5">
-                {service.fields.map((field) => (
-                  <div key={field.key} className="space-y-1.5">
-                    <Label htmlFor={`${service.id}-${field.key}`} className="text-xs font-medium">
-                      {field.label}
-                    </Label>
-                    <PasswordInput
-                      id={`${service.id}-${field.key}`}
-                      placeholder={field.placeholder}
-                      value={credentials[service.id]?.[field.key] ?? ""}
-                      onChange={(v) => handleChange(service.id, field.key, v)}
-                    />
-                    <p className="text-xs text-muted-foreground leading-relaxed">{field.hint}</p>
-                  </div>
-                ))}
-              </CardContent>
-            </Card>
+        {services.map((service) => {
+          const status = statuses[service.id] ?? "idle";
+          return (
+            <TabsContent key={service.id} value={service.id} className="mt-4">
+              <Card>
+                <CardContent className="px-6 py-6 space-y-5">
+                  {service.fields.map((field) => (
+                    <div key={field.key} className="space-y-1.5">
+                      <Label htmlFor={`${service.id}-${field.key}`} className="text-xs font-medium">
+                        {field.label}
+                      </Label>
+                      <PasswordInput
+                        id={`${service.id}-${field.key}`}
+                        placeholder={field.placeholder}
+                        value={credentials[service.id]?.[field.key] ?? ""}
+                        onChange={(v) => handleChange(service.id, field.key, v)}
+                      />
+                      <p className="text-xs text-muted-foreground leading-relaxed">{field.hint}</p>
+                    </div>
+                  ))}
+
+                  <Button
+                    onClick={() => handleSave(service.id)}
+                    className="w-full mt-2"
+                    disabled={status === "saving"}
+                    variant={status === "error" || status === "expired" ? "destructive" : "default"}
+                  >
+                    {status === "saving" && "Validating..."}
+                    {status === "saved" && "✓ Saved"}
+                    {status === "expired" && "Token is expired or invalid"}
+                    {status === "error" && "Failed — check your credentials"}
+                    {status === "idle" && `Save ${service.name} credentials`}
+                  </Button>
+                </CardContent>
+              </Card>
+            </TabsContent>
           );
         })}
-      </div>
-
-      <Button
-        onClick={handleSave}
-        className="w-full"
-        variant={status === "error" ? "destructive" : "default"}
-      >
-        {status === "saved" ? "✓ Saved" : status === "error" ? "Failed to save" : "Save credentials"}
-      </Button>
+      </Tabs>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add per-service tabs in Settings with independent save buttons and status per service
- Validate credentials via real API call before saving — shows "Validating..." then expired/error/saved state
- Redirect to dashboard automatically after successful save
- Add macOS native notifications when tokens expire or are about to expire (ChatGPT JWT 30min warning)

## Changes
- `src/pages/Settings.tsx` — refactored to tabbed layout, per-service save + validation
- `src/pages/Dashboard.tsx` — fires notifications on 401 responses and ChatGPT JWT expiry
- `src/lib/notify.ts` — notification helper with permission handling and JWT exp decoder
- `src-tauri/` — added `tauri-plugin-notification` plugin and capabilities

## Test plan
- [ ] Open Settings → each service has its own tab
- [ ] Enter invalid token → Save shows "Token is expired or invalid"
- [ ] Enter valid token → Save shows "✓ Saved" then redirects to dashboard
- [ ] Let a token expire → macOS notification fires on next refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)