### PR TITLE
fix: resolve TypeScript build errors blocking CI

### DIFF
--- a/src/components/dashboard/DonutChart.tsx
+++ b/src/components/dashboard/DonutChart.tsx
@@ -26,7 +26,7 @@ export function DonutChart({ usedPercent, color }: Props) {
           <Cell fill={usedPercent > 0 ? color : TRACK_COLOR} />
           <Cell fill={TRACK_COLOR} />
         </Pie>
-        <Tooltip formatter={(v: number) => [`${v}%`]} />
+        <Tooltip formatter={(v) => [`${v}%`]} />
       </PieChart>
     </ResponsiveContainer>
   );

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -3,6 +3,6 @@ import { load } from "@tauri-apps/plugin-store";
 export type Credentials = Record<string, Record<string, string>>;
 
 export async function loadCredentials(): Promise<Credentials> {
-  const store = await load("credentials.json", { autoSave: false });
+  const store = await load("credentials.json", { autoSave: false, defaults: {} });
   return (await store.get<Credentials>("credentials")) ?? {};
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -57,7 +57,7 @@ export default function Settings({ onSaved }: Props) {
   useEffect(() => {
     async function loadCreds() {
       try {
-        const store = await load("credentials.json", { autoSave: false });
+        const store = await load("credentials.json", { autoSave: false, defaults: {} });
         const saved = await store.get<Credentials>("credentials");
         if (saved) setCredentials(saved);
       } catch (e) {
@@ -101,7 +101,7 @@ export default function Settings({ onSaved }: Props) {
         return;
       }
 
-      const store = await load("credentials.json", { autoSave: false });
+      const store = await load("credentials.json", { autoSave: false, defaults: {} });
       await store.set("credentials", credentials);
       await store.save();
       setStatuses((prev) => ({ ...prev, [serviceId]: "saved" }));


### PR DESCRIPTION
## Summary

- Remove explicit `number` type annotation on Recharts `Tooltip` formatter in `DonutChart.tsx` — type is not assignable to Recharts' internal `Formatter` type
- Add required `defaults: {}` field to `StoreOptions` in `credentials.ts` and `Settings.tsx` (2 call sites) — `tauri-plugin-store` v2 requires this field

## Why

These TypeScript errors were silently passing in dev but caused the GitHub Actions CI build (`tsc`) to fail, blocking the v1.0.0 release workflow.

## Test plan

- [ ] `npm run build` completes without TypeScript errors
- [ ] Credentials load and save correctly in Settings
- [ ] Donut chart renders with tooltip showing percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)