### PR TITLE
feat: multiple accounts per service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ src-tauri/target
 # Credentials / sensitive local data
 credentials.json
 *.credentials.json
+.claude
+.superpowers

--- a/TODO.md
+++ b/TODO.md
@@ -14,70 +14,77 @@
 ## 🚧 In Progress
 
 ### Feature 1 — Menu Bar App
+
 Convert uso.ai from a standard window into a persistent macOS menu bar popup.
 
-- [x] Add `tray-icon` feature to Tauri
-- [x] Add `tauri-plugin-global-shortcut` and `tauri-plugin-positioner`
-- [x] Build tray icon — left-click toggles window
-- [x] Position window below tray icon (`TrayCenter`)
-- [x] Register global shortcut `Cmd+Shift+U` to toggle window
-- [x] Hide window on blur (click outside dismisses popup)
-- [x] Window: frameless, hidden by default, no taskbar entry
-- [x] Hide app from macOS Dock (`LSUIElement`)
+- Add `tray-icon` feature to Tauri
+- Add `tauri-plugin-global-shortcut` and `tauri-plugin-positioner`
+- Build tray icon — left-click toggles window
+- Position window below tray icon (`TrayCenter`)
+- Register global shortcut `Cmd+Shift+U` to toggle window
+- Hide window on blur (click outside dismisses popup)
+- Window: frameless, hidden by default, no taskbar entry
+- Hide app from macOS Dock (`LSUIElement`)
 
 ---
 
 ## 📋 Planned
 
 ### Feature 3 — Auto Account Detection
+
 Automatically detect credentials from local files — no manual cookie extraction.
 
-- [ ] **Cursor** — read `WorkosCursorSessionToken` from Cursor's local SQLite (`globalStorage/state.vscdb`)
-- [ ] **Claude (Chrome)** — read `sessionKey` cookie from Chrome's Cookies SQLite + decrypt via macOS Keychain
-- [ ] **Claude (Firefox)** — read `sessionKey` cookie from Firefox's unencrypted `cookies.sqlite` (fallback)
-- [ ] **Claude org ID** — auto-fetch from `https://claude.ai/api/organizations` once session key is known
-- [ ] **ChatGPT** — read bearer token from Chrome/Firefox cookies for `chatgpt.com`
-- [ ] **Frontend** — "Auto-detect" button per service in Settings, pre-fills & saves on success
-- [ ] **First launch** — silently run all detect commands; skip Settings if credentials found
+- **Cursor** — read `WorkosCursorSessionToken` from Cursor's local SQLite (`globalStorage/state.vscdb`)
+- **Claude (Chrome)** — read `sessionKey` cookie from Chrome's Cookies SQLite + decrypt via macOS Keychain
+- **Claude (Firefox)** — read `sessionKey` cookie from Firefox's unencrypted `cookies.sqlite` (fallback)
+- **Claude org ID** — auto-fetch from `https://claude.ai/api/organizations` once session key is known
+- **ChatGPT** — read bearer token from Chrome/Firefox cookies for `chatgpt.com`
+- **Frontend** — "Auto-detect" button per service in Settings, pre-fills & saves on success
+- **First launch** — silently run all detect commands; skip Settings if credentials found
 
 ---
 
 ### Feature — Claude Account Info
+
 The Claude card currently shows no email because the correct user-info endpoint is unknown. Needs investigation.
 
-- [ ] Find the right endpoint — candidates: `GET https://claude.ai/api/me`, `/api/account`, `/api/bootstrap` (check Network tab on claude.ai while logged in for a request that returns `email`)
-- [ ] Parse the response and store `email` on the `ServiceData` returned by `fetchClaudeUsage`
-- [ ] Display email under the service name in `ServiceDonutCard`, consistent with ChatGPT and Cursor
+- Find the right endpoint — candidates: `GET https://claude.ai/api/me`, `/api/account`, `/api/bootstrap` (check Network tab on claude.ai while logged in for a request that returns `email`)
+- Parse the response and store `email` on the `ServiceData` returned by `fetchClaudeUsage`
+- Display email under the service name in `ServiceDonutCard`, consistent with ChatGPT and Cursor
 
 ---
 
 ### Feature — Multiple Accounts Per Service
+
 Power users often have a personal account and a company/team account for the same service (e.g. personal Claude Pro + work Claude Team). Right now credentials are one-per-service.
 
-- [ ] **Data model** — change `credentials.json` schema from `{ claude: { orgId, sessionKey } }` to `{ claude: Account[] }` where each `Account` has a `label`, credentials, and an `active` flag
-- [ ] **Settings UI** — allow adding, labeling ("Personal", "Work"), and deleting multiple accounts per service; show which is currently active
-- [ ] **Account switcher** — add a small switcher in the dashboard card header or as a dropdown, so users can flip between accounts without going to Settings
-- [ ] **Fetch all or active** — decide whether to show usage for only the active account, or aggregate all accounts for the same service side by side
-- [ ] **Migration** — auto-migrate existing single-account credentials to the new array format on first launch after update
+- **Data model** — change `credentials.json` schema from `{ claude: { orgId, sessionKey } }` to `{ claude: Account[] }` where each `Account` has a `label`, credentials, and an `active` flag
+- **Settings UI** — allow adding, labeling ("Personal", "Work"), and deleting multiple accounts per service; show which is currently active
+- **Account switcher** — add a small switcher in the dashboard card header or as a dropdown, so users can flip between accounts without going to Settings
+- **Fetch all or active** — decide whether to show usage for only the active account, or aggregate all accounts for the same service side by side
+- **Migration** — auto-migrate existing single-account credentials to the new array format on first launch after update
 
 ---
 
 ### Feature — Token Expiry Desktop Notifications
+
 The infra for notifications already exists (`notify.ts`, `expiresWithin()`), but coverage is incomplete and the UX is passive (only fires at fetch time, not proactively).
 
-- [ ] **Background polling** — run a lightweight timer (e.g. every 10 min) that checks token expiry independently of the usage fetch cycle, so users get warned even if they haven't opened the popup recently
-- [ ] **Smarter thresholds** — warn at 24h, 2h, and 30min remaining rather than only 30min; each threshold fires only once per session (use a `Set` of already-notified tokens)
-- [ ] **Claude session key** — the `sessionKey` is not a JWT so expiry can't be decoded client-side; detect expiry by catching 401 responses and notify immediately
-- [ ] **Cursor session token** — same issue as Claude; detect via API response status
-- [ ] **Actionable notification** — include a "Open Settings" deep-link in the notification body so users can update the token in one click
+- **Background polling** — run a lightweight timer (e.g. every 10 min) that checks token expiry independently of the usage fetch cycle, so users get warned even if they haven't opened the popup recently
+- **Smarter thresholds** — warn at 24h, 2h, and 30min remaining rather than only 30min; each threshold fires only once per session (use a `Set` of already-notified tokens)
+- **Claude session key** — the `sessionKey` is not a JWT so expiry can't be decoded client-side; detect expiry by catching 401 responses and notify immediately
+- **Cursor session token** — same issue as Claude; detect via API response status
+- **Actionable notification** — include a "Open Settings" deep-link in the notification body so users can update the token in one click
 
 ---
 
 ### Feature — Automated Token / Session Key Fetching
+
 Manually copying cookies from DevTools is the biggest friction point. Several approaches exist, from semi-automatic to fully automatic.
 
 **Option A — Browser Extension (most practical)**
 Build a companion browser extension (Chrome/Firefox/Safari) that:
+
 - Intercepts requests to `claude.ai`, `chatgpt.com`, `cursor.com` and extracts the relevant auth headers/cookies automatically
 - Sends them to the desktop app via a local HTTP server (Tauri `tauri-plugin-localhost` or a small Axum server on a fixed port)
 - Re-sends whenever it detects a token refresh, keeping credentials always fresh
@@ -85,6 +92,7 @@ Build a companion browser extension (Chrome/Firefox/Safari) that:
 
 **Option B — macOS Keychain + Browser Cookie DB (no extension needed)**
 Already planned as Feature 3 (Auto Account Detection). Reads directly from:
+
 - Chrome's encrypted `Cookies` SQLite (decrypts via macOS Keychain `Chrome Safe Storage`)
 - Firefox's plain `cookies.sqlite`
 - Cursor's `globalStorage/state.vscdb`
@@ -92,6 +100,7 @@ Limitation: requires Full Disk Access permission on macOS; tokens may go stale b
 
 **Option C — Embedded Browser / WebView (most seamless, most complex)**
 Open a Tauri WebView pointed at the service's login page:
+
 - Intercept the auth cookies/headers as the user logs in, directly inside the app
 - Store the credentials automatically — user never sees a token string
 - Works for all services without a browser extension
@@ -107,3 +116,4 @@ Open a Tauri WebView pointed at the service's login page:
 - **Usage history** — store snapshots locally (SQLite), show trend charts over time
 - **Proactive alerts** — notify when usage is accelerating faster than normal (not just on expiry)
 - **Auto-updater** — Tauri updater plugin so users get new versions automatically
+

--- a/docs/superpowers/plans/2026-03-14-multi-account.md
+++ b/docs/superpowers/plans/2026-03-14-multi-account.md
@@ -1,0 +1,769 @@
+# Multi-Account Per Service Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Allow users to add multiple named accounts per service (e.g. Personal + Work Claude), each shown as its own card in the dashboard.
+
+**Architecture:** Migrate `credentials.json` from `{ serviceId: {fields} }` to `{ serviceId: Account[] }`. Dashboard iterates all accounts per service via `Promise.allSettled`. Settings manages `persisted` + `draft` state with per-account save/delete.
+
+**Tech Stack:** React + TypeScript, Tauri v2, `@tauri-apps/plugin-store` for persistence, no test framework (verify with `npm run build`).
+
+**Spec:** `docs/superpowers/specs/2026-03-14-multi-account-design.md`
+
+---
+
+## Chunk 1: Foundation — credentials.ts + types.ts
+
+### Task 1: Rewrite `src/lib/credentials.ts`
+
+**Files:**
+- Modify: `src/lib/credentials.ts`
+
+- [ ] **Step 1: Replace the file contents**
+
+```ts
+import { load } from "@tauri-apps/plugin-store";
+
+export type Account = {
+  id: string;
+  label: string;
+  credentials: Record<string, string>;
+};
+
+export type CredentialsStore = Record<string, Account[]>;
+
+export async function saveCredentials(data: CredentialsStore): Promise<void> {
+  const store = await load("credentials.json", { autoSave: false, defaults: {} });
+  await store.set("credentials", data);
+  await store.save();
+}
+
+export async function loadCredentials(): Promise<CredentialsStore> {
+  const store = await load("credentials.json", { autoSave: false, defaults: {} });
+  const raw = await store.get<Record<string, unknown>>("credentials");
+  if (!raw) return {};
+
+  let migrated = false;
+  const result: CredentialsStore = {};
+
+  for (const [serviceId, entry] of Object.entries(raw)) {
+    if (Array.isArray(entry)) {
+      result[serviceId] = entry as Account[];
+    } else if (entry !== null && typeof entry === "object") {
+      result[serviceId] = [
+        {
+          id: crypto.randomUUID(),
+          label: "Default",
+          credentials: entry as Record<string, string>,
+        },
+      ];
+      migrated = true;
+    }
+    // null / undefined / string / other → drop silently
+  }
+
+  if (migrated) {
+    await saveCredentials(result);
+  }
+
+  return result;
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+cd /Users/mijeongban/Documents/dev-ai/uso-ai && npx tsc --noEmit
+```
+
+Expected: errors only in files that still reference the old `Credentials` type — not in `credentials.ts` itself.
+
+---
+
+### Task 2: Update `src/types.ts`
+
+**Files:**
+- Modify: `src/types.ts`
+
+- [ ] **Step 1: Add `accountId` and `label` to `ServiceData`**
+
+Replace the `ServiceData` type:
+
+```ts
+export type UsageWindow = {
+  label: string;
+  usedPercent: number;
+  resetsAt: string;
+};
+
+export type ServiceStatus = "ok" | "expired" | "error" | "not_configured";
+
+export type ServiceData = {
+  accountId: string;
+  name: string;
+  label?: string;
+  plan: string;
+  status: ServiceStatus;
+  windows: UsageWindow[];
+  email?: string;
+};
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit 2>&1 | head -40
+```
+
+Expected: errors now point to `Dashboard.tsx`, `Settings.tsx`, and the API files — all of which need `accountId` — but no errors inside `types.ts` or `credentials.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/credentials.ts src/types.ts
+git commit -m "feat: multi-account data model — Account type, CredentialsStore, migration"
+```
+
+---
+
+## Chunk 2: Card Components
+
+### Task 3: Update `ServiceDonutCard` to show label
+
+**Files:**
+- Modify: `src/components/dashboard/ServiceDonutCard.tsx`
+
+- [ ] **Step 1: Update the card title line**
+
+Find this line in the `CardHeader`:
+```tsx
+<CardTitle className="text-sm font-medium">{service.name}</CardTitle>
+```
+
+Replace with:
+```tsx
+<CardTitle className="text-sm font-medium">
+  {service.label ? `${service.name} · ${service.label}` : service.name}
+</CardTitle>
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+npx tsc --noEmit 2>&1 | grep ServiceDonutCard
+```
+
+Expected: no errors in this file.
+
+---
+
+### Task 4: Update `NextResetCard` to show label
+
+**Files:**
+- Modify: `src/components/dashboard/NextResetCard.tsx`
+
+- [ ] **Step 1: Update the header line**
+
+Find:
+```tsx
+<p className="text-xs text-muted-foreground mb-1 truncate">Next reset · {service.name}</p>
+```
+
+Replace with:
+```tsx
+<p className="text-xs text-muted-foreground mb-1 truncate">
+  Next reset · {service.label ? `${service.name} · ${service.label}` : service.name}
+</p>
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+npx tsc --noEmit 2>&1 | grep NextResetCard
+```
+
+Expected: no errors in this file.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/components/dashboard/ServiceDonutCard.tsx src/components/dashboard/NextResetCard.tsx
+git commit -m "feat: show account label in service cards"
+```
+
+---
+
+## Chunk 3: Dashboard
+
+### Task 5: Rewrite `src/pages/Dashboard.tsx`
+
+**Files:**
+- Modify: `src/pages/Dashboard.tsx`
+
+The key changes:
+1. Import `CredentialsStore` and `SERVICES`
+2. Build a flat list of `(serviceId, account, accounts)` tuples from the store
+3. Filter accounts with empty/whitespace credentials
+4. Fetch all in parallel with `Promise.allSettled`
+5. Merge `accountId`, `name`, and `label` into each `ServiceData`
+6. Update ChatGPT expiry warning to iterate accounts
+7. Update expired-token notifications to include label
+8. Use `key={s.accountId}` on both card components
+
+- [ ] **Step 1: Replace the file contents**
+
+```tsx
+import { useState, useEffect, useCallback } from "react";
+import { RefreshCw } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { loadCredentials } from "@/lib/credentials";
+import { fetchClaudeUsage } from "@/lib/api/claude";
+import { fetchChatGPTUsage } from "@/lib/api/chatgpt";
+import { fetchCursorUsage } from "@/lib/api/cursor";
+import { NextResetCard } from "@/components/dashboard/NextResetCard";
+import { ServiceDonutCard } from "@/components/dashboard/ServiceDonutCard";
+import { notify, expiresWithin } from "@/lib/notify";
+import { SERVICES } from "@/lib/services";
+import type { Account, CredentialsStore } from "@/lib/credentials";
+import type { ServiceData } from "@/types";
+
+type Props = { onNavigateToSettings?: () => void };
+
+function SkeletonCard() {
+  return (
+    <Card>
+      <CardContent className="p-4 space-y-3">
+        <div className="h-3 w-20 bg-secondary rounded animate-pulse" />
+        <div className="flex items-center gap-4">
+          <div className="w-[120px] h-[120px] rounded-full bg-secondary animate-pulse" />
+          <div className="space-y-2 flex-1">
+            <div className="h-3 w-24 bg-secondary rounded animate-pulse" />
+            <div className="h-3 w-16 bg-secondary rounded animate-pulse" />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+function formatLastUpdated(date: Date): string {
+  const diff = Math.round((Date.now() - date.getTime()) / 1000);
+  if (diff < 60) return "just now";
+  return `${Math.round(diff / 60)}m ago`;
+}
+
+/** Returns true if all credential fields for this account are non-blank. */
+function isAccountConfigured(serviceId: string, account: Account): boolean {
+  const service = SERVICES.find((s) => s.id === serviceId);
+  if (!service) return false;
+  return service.fields.every((f) => !!account.credentials[f.key]?.trim());
+}
+
+async function fetchAccount(
+  serviceId: string,
+  account: Account,
+  label: string | undefined
+): Promise<ServiceData> {
+  const serviceName = SERVICES.find((s) => s.id === serviceId)?.name ?? serviceId;
+  const creds = account.credentials;
+
+  let result: ServiceData;
+  if (serviceId === "claude") {
+    result = await fetchClaudeUsage(creds.orgId, creds.sessionKey);
+  } else if (serviceId === "chatgpt") {
+    result = await fetchChatGPTUsage(creds.bearerToken);
+  } else if (serviceId === "cursor") {
+    result = await fetchCursorUsage(creds.sessionToken);
+  } else {
+    result = { accountId: account.id, name: serviceName, plan: "", status: "error", windows: [] };
+  }
+
+  return { ...result, accountId: account.id, name: serviceName, label };
+}
+
+export default function Dashboard({ onNavigateToSettings }: Props) {
+  const [services, setServices] = useState<ServiceData[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    setFetchError(null);
+    try {
+      const creds: CredentialsStore = await loadCredentials();
+
+      // ChatGPT pre-fetch expiry warning
+      const chatgptAccounts = creds.chatgpt ?? [];
+      const isMultiChatGPT = chatgptAccounts.length > 1;
+      for (let i = 0; i < chatgptAccounts.length; i++) {
+        const acc = chatgptAccounts[i];
+        const token = acc.credentials.bearerToken;
+        if (token && expiresWithin(token, 30)) {
+          const displayLabel = isMultiChatGPT
+            ? (acc.label.trim() || `Account ${i + 1}`)
+            : null;
+          const body = displayLabel
+            ? `Your ChatGPT (Codex) · ${displayLabel} Bearer token expires in less than 30 minutes. Update it in Settings.`
+            : "Your ChatGPT Bearer token expires in less than 30 minutes. Update it in Settings.";
+          await notify("uso.ai · ChatGPT token expiring soon", body);
+        }
+      }
+
+      // Build list of accounts to fetch, in service order
+      const toFetch: { serviceId: string; account: Account; label: string | undefined }[] = [];
+      for (const serviceId of ["claude", "chatgpt", "cursor"]) {
+        const accounts = creds[serviceId] ?? [];
+        const showLabel = accounts.length > 1;
+        for (const account of accounts) {
+          if (isAccountConfigured(serviceId, account)) {
+            toFetch.push({ serviceId, account, label: showLabel ? account.label : undefined });
+          }
+        }
+      }
+
+      const settled = await Promise.allSettled(
+        toFetch.map(({ serviceId, account, label }) =>
+          fetchAccount(serviceId, account, label)
+        )
+      );
+
+      const results: ServiceData[] = settled.map((result, i) => {
+        const { serviceId, account, label } = toFetch[i];
+        const serviceName = SERVICES.find((s) => s.id === serviceId)?.name ?? serviceId;
+        if (result.status === "fulfilled") return result.value;
+        return { accountId: account.id, name: serviceName, label, plan: "", status: "error" as const, windows: [] };
+      });
+
+      // Expired-token notifications
+      for (const s of results.filter((r) => r.status === "expired")) {
+        const nameWithLabel = s.label ? `${s.name} · ${s.label}` : s.name;
+        await notify(
+          `uso.ai · ${nameWithLabel} token expired`,
+          `Your ${nameWithLabel} session token has expired. Update it in Settings.`
+        );
+      }
+
+      setServices(results.filter((r): r is ServiceData => r !== null));
+      setLastUpdated(new Date());
+    } catch (e) {
+      console.error("Failed to fetch usage data", e);
+      setFetchError(String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+    const interval = setInterval(fetchAll, 5 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, [fetchAll]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        {lastUpdated && (
+          <p className="text-xs text-muted-foreground">
+            Updated {formatLastUpdated(lastUpdated)}
+          </p>
+        )}
+        <button
+          onClick={fetchAll}
+          disabled={loading}
+          className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors disabled:opacity-50 ml-auto"
+        >
+          <RefreshCw size={12} className={loading ? "animate-spin" : ""} />
+          Refresh
+        </button>
+      </div>
+
+      {fetchError && (
+        <p className="text-xs text-red-500 text-center">{fetchError}</p>
+      )}
+
+      {!loading && services.length === 0 && !fetchError && (
+        <p className="text-center text-sm text-muted-foreground py-12">
+          No services configured.{" "}
+          <button onClick={onNavigateToSettings} className="underline hover:text-foreground transition-colors">
+            Add credentials in Settings.
+          </button>
+        </p>
+      )}
+
+      {services.length > 0 && (
+        <>
+          <div className="flex gap-3">
+            {services.filter((s) => s.status === "ok").map((s) => (
+              <NextResetCard key={s.accountId} service={s} />
+            ))}
+          </div>
+
+          <div className="space-y-3">
+            {loading && services.length === 0 ? (
+              <><SkeletonCard /><SkeletonCard /></>
+            ) : (
+              services.map((s) => (
+                <ServiceDonutCard key={s.accountId} service={s} onSettings={onNavigateToSettings} />
+              ))
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npx tsc --noEmit 2>&1 | grep -v "Settings.tsx"
+```
+
+Expected: no errors except possibly in `Settings.tsx` (not yet updated).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/pages/Dashboard.tsx
+git commit -m "feat: dashboard iterates all accounts via Promise.allSettled"
+```
+
+---
+
+## Chunk 4: Settings
+
+### Task 6: Rewrite `src/pages/Settings.tsx`
+
+**Files:**
+- Modify: `src/pages/Settings.tsx`
+
+The key changes:
+1. Load into `persisted` + `draft` state on mount
+2. Render per-account sections per service tab
+3. Save button: per-account, disabled when credential fields blank, writes `{ ...persisted, [serviceId]: draft[serviceId] }`
+4. Delete: unsaved → remove from draft; persisted → write to store immediately
+5. "+ Add account" button
+6. `statuses` keyed by `account.id`
+7. `isConfigured` tab indicator checks any account in `persisted`
+
+- [ ] **Step 1: Replace the file contents**
+
+```tsx
+import { useState, useEffect } from "react";
+import { Eye, EyeOff, CheckCircle2, Circle, Trash2 } from "lucide-react";
+import { Card, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
+import { ServiceAvatar } from "@/components/ServiceAvatar";
+import { SERVICES } from "@/lib/services";
+import { loadCredentials, saveCredentials } from "@/lib/credentials";
+import { fetchClaudeUsage } from "@/lib/api/claude";
+import { fetchChatGPTUsage } from "@/lib/api/chatgpt";
+import { fetchCursorUsage } from "@/lib/api/cursor";
+import type { Account, CredentialsStore } from "@/lib/credentials";
+
+function PasswordInput({
+  id, placeholder, value, onChange,
+}: {
+  id: string;
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  const [show, setShow] = useState(false);
+  return (
+    <div className="relative">
+      <Input
+        id={id}
+        type={show ? "text" : "password"}
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="pr-9 font-mono text-xs"
+      />
+      <button
+        type="button"
+        onClick={() => setShow((s) => !s)}
+        className="absolute right-2.5 top-1/2 -translate-y-1/2 text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {show ? <EyeOff size={14} /> : <Eye size={14} />}
+      </button>
+    </div>
+  );
+}
+
+type StatusMap = Record<string, "idle" | "saving" | "saved" | "expired" | "error">;
+
+type Props = { onSaved?: () => void };
+
+function isAccountConfigured(account: Account, fields: { key: string }[]): boolean {
+  return fields.every((f) => !!account.credentials[f.key]?.trim());
+}
+
+function isServiceConfigured(accounts: Account[], fields: { key: string }[]): boolean {
+  return accounts.some((a) => isAccountConfigured(a, fields));
+}
+
+function isPersistedAccountDeletable(persisted: CredentialsStore, serviceId: string, accountId: string): boolean {
+  const accounts = persisted[serviceId] ?? [];
+  if (accounts.length !== 1) return true; // multiple accounts — always deletable
+  // Only account: hide delete if it has at least one non-empty credential field
+  const sole = accounts[0];
+  const service = SERVICES.find((s) => s.id === serviceId);
+  const hasAnyField = service?.fields.some((f) => !!sole.credentials[f.key]?.trim()) ?? false;
+  return !hasAnyField; // show delete only if all fields are empty (broken state)
+}
+
+export default function Settings({ onSaved }: Props) {
+  const [persisted, setPersisted] = useState<CredentialsStore>({});
+  const [draft, setDraft] = useState<CredentialsStore>({});
+  const [statuses, setStatuses] = useState<StatusMap>({});
+
+  useEffect(() => {
+    loadCredentials().then((creds) => {
+      // Ensure every service has an array entry
+      const normalized: CredentialsStore = {};
+      for (const s of SERVICES) {
+        normalized[s.id] = creds[s.id] ?? [];
+      }
+      setPersisted(normalized);
+      setDraft(JSON.parse(JSON.stringify(normalized))); // deep copy
+    });
+  }, []);
+
+  function setAccountField(serviceId: string, accountId: string, key: string, value: string) {
+    setDraft((prev) => ({
+      ...prev,
+      [serviceId]: (prev[serviceId] ?? []).map((a) =>
+        a.id === accountId ? { ...a, credentials: { ...a.credentials, [key]: value } } : a
+      ),
+    }));
+    setStatuses((prev) => ({ ...prev, [accountId]: "idle" }));
+  }
+
+  function setAccountLabel(serviceId: string, accountId: string, value: string) {
+    setDraft((prev) => ({
+      ...prev,
+      [serviceId]: (prev[serviceId] ?? []).map((a) =>
+        a.id === accountId ? { ...a, label: value } : a
+      ),
+    }));
+  }
+
+  function addAccount(serviceId: string) {
+    const current = draft[serviceId] ?? [];
+    const newAccount: Account = {
+      id: crypto.randomUUID(),
+      label: `Account ${current.length + 1}`,
+      credentials: {},
+    };
+    setDraft((prev) => ({ ...prev, [serviceId]: [...(prev[serviceId] ?? []), newAccount] }));
+  }
+
+  async function deleteAccount(serviceId: string, accountId: string) {
+    const isInPersisted = (persisted[serviceId] ?? []).some((a) => a.id === accountId);
+    const newDraft = { ...draft, [serviceId]: (draft[serviceId] ?? []).filter((a) => a.id !== accountId) };
+    setDraft(newDraft);
+    if (isInPersisted) {
+      const newPersisted = { ...persisted, [serviceId]: (persisted[serviceId] ?? []).filter((a) => a.id !== accountId) };
+      await saveCredentials(newPersisted);
+      setPersisted(newPersisted);
+    }
+  }
+
+  async function handleSave(serviceId: string, accountId: string) {
+    setStatuses((prev) => ({ ...prev, [accountId]: "saving" }));
+    try {
+      const account = (draft[serviceId] ?? []).find((a) => a.id === accountId);
+      if (!account) return;
+      const creds = account.credentials;
+      let validationStatus = "ok";
+
+      if (serviceId === "claude" && creds.orgId && creds.sessionKey) {
+        const result = await fetchClaudeUsage(creds.orgId, creds.sessionKey);
+        validationStatus = result.status;
+      } else if (serviceId === "chatgpt" && creds.bearerToken) {
+        const result = await fetchChatGPTUsage(creds.bearerToken);
+        validationStatus = result.status;
+      } else if (serviceId === "cursor" && creds.sessionToken) {
+        const result = await fetchCursorUsage(creds.sessionToken);
+        validationStatus = result.status;
+      }
+
+      if (validationStatus === "expired") {
+        setStatuses((prev) => ({ ...prev, [accountId]: "expired" }));
+        return;
+      }
+      if (validationStatus === "error") {
+        setStatuses((prev) => ({ ...prev, [accountId]: "error" }));
+        return;
+      }
+
+      const newPersisted = { ...persisted, [serviceId]: draft[serviceId] ?? [] };
+      await saveCredentials(newPersisted);
+      setPersisted(newPersisted);
+      setStatuses((prev) => ({ ...prev, [accountId]: "saved" }));
+      setTimeout(() => {
+        setStatuses((prev) => ({ ...prev, [accountId]: "idle" }));
+        onSaved?.();
+      }, 800);
+    } catch (e) {
+      console.error("Failed to save credentials", e);
+      setStatuses((prev) => ({ ...prev, [accountId]: "error" }));
+    }
+  }
+
+  return (
+    <div className="max-w-lg mx-auto space-y-6">
+      <div>
+        <h2 className="text-base font-semibold">Credentials</h2>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Session tokens are stored locally and never leave this app.
+        </p>
+      </div>
+
+      <Tabs defaultValue="claude">
+        <TabsList className="w-full">
+          {SERVICES.map((service) => {
+            const configured = isServiceConfigured(persisted[service.id] ?? [], service.fields);
+            return (
+              <TabsTrigger key={service.id} value={service.id} className="flex-1 gap-2">
+                <ServiceAvatar name={service.name} size="sm" />
+                {service.name}
+                {configured
+                  ? <CheckCircle2 size={12} className="text-muted-foreground ml-auto" />
+                  : <Circle size={12} className="text-muted-foreground/40 ml-auto" />
+                }
+              </TabsTrigger>
+            );
+          })}
+        </TabsList>
+
+        {SERVICES.map((service) => {
+          const accounts = draft[service.id] ?? [];
+          return (
+            <TabsContent key={service.id} value={service.id} className="mt-4 space-y-4">
+              {accounts.map((account) => {
+                const status = statuses[account.id] ?? "idle";
+                const isUnsaved = !(persisted[service.id] ?? []).some((a) => a.id === account.id);
+                const showDelete = isUnsaved || isPersistedAccountDeletable(persisted, service.id, account.id);
+                const canSave = service.fields.every((f) => !!account.credentials[f.key]?.trim());
+
+                return (
+                  <Card key={account.id}>
+                    <CardContent className="px-6 py-6 space-y-5">
+                      {/* Label */}
+                      <div className="space-y-1.5">
+                        <Label htmlFor={`${account.id}-label`} className="text-xs font-medium">
+                          Account label
+                        </Label>
+                        <Input
+                          id={`${account.id}-label`}
+                          placeholder="e.g. Personal, Work"
+                          value={account.label}
+                          onChange={(e) => setAccountLabel(service.id, account.id, e.target.value)}
+                          className="text-xs"
+                        />
+                      </div>
+
+                      {/* Credential fields */}
+                      {service.fields.map((field) => (
+                        <div key={field.key} className="space-y-1.5">
+                          <Label htmlFor={`${account.id}-${field.key}`} className="text-xs font-medium">
+                            {field.label}
+                          </Label>
+                          <PasswordInput
+                            id={`${account.id}-${field.key}`}
+                            placeholder={field.placeholder}
+                            value={account.credentials[field.key] ?? ""}
+                            onChange={(v) => setAccountField(service.id, account.id, field.key, v)}
+                          />
+                          <p className="text-xs text-muted-foreground leading-relaxed">{field.hint}</p>
+                        </div>
+                      ))}
+
+                      {/* Actions */}
+                      <div className="flex items-center gap-3">
+                        <Button
+                          onClick={() => handleSave(service.id, account.id)}
+                          className="flex-1"
+                          disabled={status === "saving" || !canSave}
+                          variant={status === "error" || status === "expired" ? "destructive" : "default"}
+                        >
+                          {status === "saving" && "Validating..."}
+                          {status === "saved" && "✓ Saved"}
+                          {status === "expired" && "Token is expired or invalid"}
+                          {status === "error" && "Failed — check your credentials"}
+                          {(status === "idle") && `Save ${service.name} credentials`}
+                        </Button>
+                        {showDelete && (
+                          <button
+                            type="button"
+                            onClick={() => deleteAccount(service.id, account.id)}
+                            className="text-muted-foreground hover:text-destructive transition-colors"
+                            title="Delete account"
+                          >
+                            <Trash2 size={15} />
+                          </button>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={() => addAccount(service.id)}
+              >
+                + Add account
+              </Button>
+            </TabsContent>
+          );
+        })}
+      </Tabs>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles with zero errors**
+
+```bash
+npx tsc --noEmit
+```
+
+Expected: exit 0, no output.
+
+- [ ] **Step 3: Full build check**
+
+```bash
+npm run build
+```
+
+Expected: `✓ built in Xs` with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pages/Settings.tsx
+git commit -m "feat: multi-account Settings UI with per-account save/delete/add"
+```
+
+---
+
+## Final verification
+
+- [ ] Run `npm run tauri dev` and manually verify:
+  - [ ] Existing saved credentials still appear (migration worked — shows as "Default" label)
+  - [ ] "+ Add account" adds a new section in Settings
+  - [ ] Saving an account writes to store; refreshing app shows it persisted
+  - [ ] Deleting an account works; last persisted account with fields hides the delete button
+  - [ ] Dashboard shows two cards when two accounts are configured for same service, each with `"Service · Label"` header
+  - [ ] Single account shows no label (just service name)
+  - [ ] Token expiry / error states still work per-card

--- a/docs/superpowers/specs/2026-03-14-multi-account-design.md
+++ b/docs/superpowers/specs/2026-03-14-multi-account-design.md
@@ -1,0 +1,151 @@
+# Multi-Account Per Service — Design Spec
+
+**Date:** 2026-03-14
+**Status:** Approved
+**Scope:** uso.ai — Tauri v2 + React/TypeScript macOS menu bar app
+
+---
+
+## Problem
+
+Credentials are stored one-per-service. Power users with both a personal and a work account for the same service (e.g. Claude Pro + Claude Team) cannot track both at once.
+
+---
+
+## Design
+
+### 1. Data Model
+
+`credentials.json` changes from a flat object to arrays of accounts per service.
+
+**Old format:**
+```json
+{
+  "claude":  { "orgId": "...", "sessionKey": "..." },
+  "chatgpt": { "bearerToken": "..." },
+  "cursor":  { "sessionToken": "..." }
+}
+```
+
+**New format:**
+```json
+{
+  "claude": [
+    { "id": "abc123", "label": "Personal", "credentials": { "orgId": "...", "sessionKey": "..." } }
+  ]
+}
+```
+
+**TypeScript types** (`src/lib/credentials.ts` — existing file, rewritten):
+```ts
+export type Account = {
+  id: string;                          // generated via crypto.randomUUID()
+  label: string;
+  credentials: Record<string, string>;
+};
+
+export type CredentialsStore = Record<string, Account[]>;
+```
+
+**ID generation:** All account IDs are generated with `crypto.randomUUID()`.
+
+**`loadCredentials(): Promise<CredentialsStore>`** — reads the raw value from the store and migrates per service. For each service entry:
+- `Array.isArray(entry)` → already migrated, leave unchanged
+- Plain object (typeof === "object" && not null) → wrap: `[{ id: crypto.randomUUID(), label: "Default", credentials: { ...entry } }]`
+- Any other value (null, undefined, string, etc.) → skip/drop that service key
+
+If any migration occurred, call `saveCredentials(migratedStore)` before returning.
+
+**`saveCredentials(data: CredentialsStore): Promise<void>`** — module-level export. Opens the Tauri store, calls `store.set("credentials", data)`, then `store.save()`. `credentials.json` holds only the `"credentials"` key — no other keys are present — so overwriting it is safe.
+
+---
+
+### 2. Settings UI
+
+Settings maintains two pieces of local state:
+- **`persisted: CredentialsStore`** — initialized from `loadCredentials()` on mount; missing service keys default to `[]`
+- **`draft: CredentialsStore`** — initialized as a deep copy of `persisted` on mount; missing service keys default to `[]`
+
+Each service tab renders a vertical list of account sections, driven by `draft[serviceId]`. Each section contains:
+
+- **Label field** — free-text input (placeholder: "e.g. Personal, Work"); optional — empty or whitespace-only label does not block saving
+- **Credential fields** — same `PasswordInput` fields as today, driven by `service.fields`
+- **Save button:**
+  - Disabled if any **credential** field for this account is empty or whitespace-only (`!value.trim()`)
+  - When clicked, calls the same service API fetch function as the dashboard (e.g. `fetchClaudeUsage` for Claude) to validate; `"ok"` proceeds, `"expired"` and `"error"` set their respective statuses and return early
+  - On success: writes `{ ...persisted, [serviceId]: draft[serviceId] }` via `saveCredentials()`, updates `persisted` to match, calls `onSaved?.()` inside the 800ms reset timeout
+  - One `onSaved` call per successful account save is intentional — the callback triggers the parent to re-fetch, which is appropriate even for partial saves
+  - Shows `saving / saved / expired / error` states keyed by `account.id`; auto-resets `"saved"` → `"idle"` after 800ms
+- **Delete link:**
+  - **Unsaved account** (in `draft` but not in `persisted`): removes from `draft` state only, no store write; always shown
+  - **Persisted account**: calls `saveCredentials()` immediately with this account removed; hidden when it is the only account in `persisted[serviceId]` AND that account has at least one non-empty credential field; if the sole persisted account has all-empty credentials, Delete is shown so the user can remove a broken state
+
+**`statuses` state:** `Record<string, "idle" | "saving" | "saved" | "expired" | "error">` keyed by `account.id`. New accounts start at `"idle"`.
+
+**"+ Add account" button:** Appends to `draft[serviceId]` a new section with `id: crypto.randomUUID()` and label `"Account N"` where N = `draft[serviceId].length + 1`. Labels are non-unique editable suggestions — duplicates after deletions are acceptable.
+
+**"Configured" tab indicator:** Shows `CheckCircle2` when at least one account in `persisted[serviceId]` has all credential fields non-empty and non-whitespace. `draft` state is not considered.
+
+---
+
+### 3. Dashboard
+
+**`ServiceData` type** (`src/types.ts`):
+```ts
+export type ServiceData = {
+  accountId: string;  // from Account.id — used as React key
+  name: string;       // SERVICES.find(s => s.id === serviceId)?.name
+  label?: string;     // present only when accounts.length > 1 for this service
+  plan: string;
+  status: ServiceStatus;  // "not_configured" retained in union but never emitted by fetch flow
+  windows: UsageWindow[];
+  email?: string;
+};
+```
+
+The `name` field is always sourced from `SERVICES` config (e.g. `"ChatGPT (Codex)"`), ensuring `getServiceByName(service.name)` always resolves correctly.
+
+**Label display rule:** `label` is set on `ServiceData` only when `accounts.length > 1` for that service.
+
+**Account filtering:** Before fetching, skip any account where any credential field is empty or whitespace-only. Skipped accounts produce no `ServiceData` and no card. `not_configured` is never set on any emitted `ServiceData`.
+
+**Fetch flow:** All non-skipped accounts across all services are fetched in parallel via `Promise.allSettled`. Each fetch function receives credential values from `account.credentials` (same call signatures as today). Processing results:
+- Fulfilled (`status: "fulfilled"`) → use `result.value` as `ServiceData`, with `accountId` and `name`/`label` merged in
+- Rejected (`status: "rejected"`) → produce `{ accountId, name, label, status: "error", plan: "", windows: [] }`
+
+**Expired-token notifications:** After `Promise.allSettled`, collect all `ServiceData` where `status === "expired"`. For each, fire a notification. Message includes label when present: `"Your {name} · {label} session token has expired."` — if no label (single account), use the existing message format.
+
+**ChatGPT expiry warning (pre-fetch):** Iterates all ChatGPT accounts from `CredentialsStore`. For each account with a non-blank `bearerToken`, checks `expiresWithin(token, 30)`. Notification:
+- Single ChatGPT account: existing message unchanged
+- Multiple accounts: `"Your ChatGPT (Codex) · {displayLabel} Bearer token expires in less than 30 minutes."` where `displayLabel` = stored label if non-blank, otherwise `"Account N"` (1-based position in current array)
+
+If `loadCredentials()` itself rejects, the existing `fetchError` state and red error string rendering are preserved unchanged.
+
+**Card order:** Claude accounts first, then ChatGPT, then Cursor. Within a service, accounts appear in array insertion order.
+
+**React keys:** Both `ServiceDonutCard` and `NextResetCard` use `key={s.accountId}` at their call sites in `Dashboard.tsx`.
+
+**`ServiceDonutCard` header:** Renders `"{service.name} · {label}"` when `label` is present; otherwise `service.name`. `getServiceByName` receives the raw `service.name`.
+
+**`NextResetCard` header:** Same rule — renders `"{service.name} · {label}"` when `label` is present.
+
+---
+
+### 4. Files Changed
+
+| File | Change |
+|------|--------|
+| `src/lib/credentials.ts` | Rewrite: new `Account` + `CredentialsStore` types; updated `loadCredentials()` with per-service migration; new `saveCredentials(data)` module-level export |
+| `src/types.ts` | Add `accountId: string` and `label?: string` to `ServiceData`; retain `not_configured` in `ServiceStatus` |
+| `src/pages/Settings.tsx` | Rewrite: `persisted` + `draft` state; per-account sections with add/delete; `statuses` keyed by `account.id`; Save disabled on empty/whitespace credential fields; preserve `onSaved` prop |
+| `src/pages/Dashboard.tsx` | Iterate all accounts per service; filter unconfigured; `Promise.allSettled` with per-account error isolation; source `name` from `SERVICES` config; pass `accountId` + `label` into `ServiceData`; update notifications for multi-account; update ChatGPT expiry check; use `key={s.accountId}` at both card call sites; preserve `fetchError` handling |
+| `src/components/dashboard/ServiceDonutCard.tsx` | Render `"{name} · {label}"` in title when `label` is present |
+| `src/components/dashboard/NextResetCard.tsx` | Render `"{name} · {label}"` in header when `label` is present |
+
+---
+
+### 5. Out of Scope
+
+- Active/inactive flag — all accounts always fetched and shown
+- Account reordering — insertion order only
+- Aggregating usage across accounts for the same service — each card is independent

--- a/src/components/dashboard/NextResetCard.tsx
+++ b/src/components/dashboard/NextResetCard.tsx
@@ -9,7 +9,9 @@ export function NextResetCard({ service }: { service: ServiceData }) {
   return (
     <Card className="flex-1 min-w-0">
       <CardContent className="px-3 py-3">
-        <p className="text-xs text-muted-foreground mb-1 truncate">Next reset · {service.name}</p>
+        <p className="text-xs text-muted-foreground mb-1 truncate">
+          Next reset · {service.label ? `${service.name} · ${service.label}` : service.name}
+        </p>
         <p className="text-base font-semibold leading-tight truncate" style={{ color }}>
           {soonest ? soonest.resetsAt : "—"}
         </p>

--- a/src/components/dashboard/ServiceDonutCard.tsx
+++ b/src/components/dashboard/ServiceDonutCard.tsx
@@ -25,7 +25,9 @@ export function ServiceDonutCard({ service, onSettings }: Props) {
         <div className="flex items-center gap-2">
           <ServiceAvatar name={service.name} />
           <div>
-            <CardTitle className="text-sm font-medium">{service.name}</CardTitle>
+            <CardTitle className="text-sm font-medium">
+              {service.label ? `${service.name} · ${service.label}` : service.name}
+            </CardTitle>
             {service.email && (
               <p className="text-xs text-muted-foreground">{service.email}</p>
             )}

--- a/src/lib/api/chatgpt.ts
+++ b/src/lib/api/chatgpt.ts
@@ -67,10 +67,10 @@ export async function fetchChatGPTUsage(bearerToken: string): Promise<ServiceDat
   });
 
   if (res.status === 401 || res.status === 403) {
-    return { name: "ChatGPT (Codex)", plan: "Plus", status: "expired", windows: [] };
+    return { name: "ChatGPT (Codex)", plan: "Plus", status: "expired", windows: [], accountId: "" };
   }
   if (!res.ok) {
-    return { name: "ChatGPT (Codex)", plan: "Plus", status: "error", windows: [] };
+    return { name: "ChatGPT (Codex)", plan: "Plus", status: "error", windows: [], accountId: "" };
   }
 
   const data = (await res.json()) as ChatGPTUsageResponse;
@@ -124,5 +124,5 @@ const plan = data.plan_type === "plus" ? "Plus" : data.plan_type;
   }
 
   const email = await fetchChatGPTEmail(bearerToken);
-  return { name: "ChatGPT (Codex)", plan, status: "ok", windows, email };
+  return { name: "ChatGPT (Codex)", plan, status: "ok", windows, email, accountId: "" };
 }

--- a/src/lib/api/claude.ts
+++ b/src/lib/api/claude.ts
@@ -54,10 +54,10 @@ export async function fetchClaudeUsage(
   );
 
   if (res.status === 401 || res.status === 403) {
-    return { name: "Claude", plan: "Pro", status: "expired", windows: [] };
+    return { name: "Claude", plan: "Pro", status: "expired", windows: [], accountId: "" };
   }
   if (!res.ok) {
-    return { name: "Claude", plan: "Pro", status: "error", windows: [] };
+    return { name: "Claude", plan: "Pro", status: "error", windows: [], accountId: "" };
   }
 
   const data = (await res.json()) as ClaudeUsageResponse;
@@ -79,5 +79,5 @@ const windows = [];
   }
 
   const email = await fetchClaudeEmail(sessionKey);
-  return { name: "Claude", plan: "Pro", status: "ok", windows, email };
+  return { name: "Claude", plan: "Pro", status: "ok", windows, email, accountId: "" };
 }

--- a/src/lib/api/cursor.ts
+++ b/src/lib/api/cursor.ts
@@ -44,10 +44,10 @@ export async function fetchCursorUsage(sessionToken: string): Promise<ServiceDat
   });
 
   if (res.status === 401 || res.status === 403) {
-    return { name: "Cursor", plan: "Free", status: "expired", windows: [] };
+    return { name: "Cursor", plan: "Free", status: "expired", windows: [], accountId: "" };
   }
   if (!res.ok) {
-    return { name: "Cursor", plan: "Free", status: "error", windows: [] };
+    return { name: "Cursor", plan: "Free", status: "error", windows: [], accountId: "" };
   }
 
   const data = (await res.json()) as CursorUsageResponse;
@@ -70,6 +70,7 @@ const plan =
     plan,
     status: "ok",
     email,
+    accountId: "",
     windows: [
       { label: `Auto · ${period}`, usedPercent: autoPercent, resetsAt },
       { label: `API · ${period}`, usedPercent: apiPercent, resetsAt },

--- a/src/lib/credentials.ts
+++ b/src/lib/credentials.ts
@@ -1,8 +1,46 @@
 import { load } from "@tauri-apps/plugin-store";
 
-export type Credentials = Record<string, Record<string, string>>;
+export type Account = {
+  id: string;
+  label: string;
+  credentials: Record<string, string>;
+};
 
-export async function loadCredentials(): Promise<Credentials> {
+export type CredentialsStore = Record<string, Account[]>;
+
+export async function saveCredentials(data: CredentialsStore): Promise<void> {
   const store = await load("credentials.json", { autoSave: false, defaults: {} });
-  return (await store.get<Credentials>("credentials")) ?? {};
+  await store.set("credentials", data);
+  await store.save();
+}
+
+export async function loadCredentials(): Promise<CredentialsStore> {
+  const store = await load("credentials.json", { autoSave: false, defaults: {} });
+  const raw = await store.get<Record<string, unknown>>("credentials");
+  if (!raw) return {};
+
+  let migrated = false;
+  const result: CredentialsStore = {};
+
+  for (const [serviceId, entry] of Object.entries(raw)) {
+    if (Array.isArray(entry)) {
+      result[serviceId] = entry as Account[];
+    } else if (entry !== null && typeof entry === "object") {
+      result[serviceId] = [
+        {
+          id: crypto.randomUUID(),
+          label: "Default",
+          credentials: entry as Record<string, string>,
+        },
+      ];
+      migrated = true;
+    }
+    // null / undefined / string / other → drop silently
+  }
+
+  if (migrated) {
+    await saveCredentials(result);
+  }
+
+  return result;
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -177,7 +177,7 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
 
       {services.length > 0 && (
         <>
-          <div className="flex gap-3">
+          <div className="grid grid-cols-2 gap-3">
             {services.filter((s) => s.status === "ok").map((s) => (
               <NextResetCard key={s.accountId} service={s} />
             ))}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -8,6 +8,8 @@ import { fetchCursorUsage } from "@/lib/api/cursor";
 import { NextResetCard } from "@/components/dashboard/NextResetCard";
 import { ServiceDonutCard } from "@/components/dashboard/ServiceDonutCard";
 import { notify, expiresWithin } from "@/lib/notify";
+import { SERVICES } from "@/lib/services";
+import type { Account, CredentialsStore } from "@/lib/credentials";
 import type { ServiceData } from "@/types";
 
 type Props = { onNavigateToSettings?: () => void };
@@ -35,6 +37,35 @@ function formatLastUpdated(date: Date): string {
   return `${Math.round(diff / 60)}m ago`;
 }
 
+/** Returns true if all credential fields for this account are non-blank. */
+function isAccountConfigured(serviceId: string, account: Account): boolean {
+  const service = SERVICES.find((s) => s.id === serviceId);
+  if (!service) return false;
+  return service.fields.every((f) => !!account.credentials[f.key]?.trim());
+}
+
+async function fetchAccount(
+  serviceId: string,
+  account: Account,
+  label: string | undefined
+): Promise<ServiceData> {
+  const serviceName = SERVICES.find((s) => s.id === serviceId)?.name ?? serviceId;
+  const creds = account.credentials;
+
+  let result: ServiceData;
+  if (serviceId === "claude") {
+    result = await fetchClaudeUsage(creds.orgId, creds.sessionKey);
+  } else if (serviceId === "chatgpt") {
+    result = await fetchChatGPTUsage(creds.bearerToken);
+  } else if (serviceId === "cursor") {
+    result = await fetchCursorUsage(creds.sessionToken);
+  } else {
+    result = { accountId: account.id, name: serviceName, plan: "", status: "error", windows: [] };
+  }
+
+  return { ...result, accountId: account.id, name: serviceName, label };
+}
+
 export default function Dashboard({ onNavigateToSettings }: Props) {
   const [services, setServices] = useState<ServiceData[]>([]);
   const [loading, setLoading] = useState(true);
@@ -45,29 +76,57 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
     setLoading(true);
     setFetchError(null);
     try {
-      const creds = await loadCredentials();
+      const creds: CredentialsStore = await loadCredentials();
 
-      // Warn if ChatGPT JWT expires within 30 minutes
-      if (creds.chatgpt?.bearerToken && expiresWithin(creds.chatgpt.bearerToken, 30)) {
-        await notify("uso.ai · ChatGPT token expiring soon", "Your ChatGPT Bearer token expires in less than 30 minutes. Update it in Settings.");
+      // ChatGPT pre-fetch expiry warning
+      const chatgptAccounts = creds.chatgpt ?? [];
+      const isMultiChatGPT = chatgptAccounts.length > 1;
+      for (let i = 0; i < chatgptAccounts.length; i++) {
+        const acc = chatgptAccounts[i];
+        const token = acc.credentials.bearerToken;
+        if (token && expiresWithin(token, 30)) {
+          const displayLabel = isMultiChatGPT
+            ? (acc.label.trim() || `Account ${i + 1}`)
+            : null;
+          const body = displayLabel
+            ? `Your ChatGPT (Codex) · ${displayLabel} Bearer token expires in less than 30 minutes. Update it in Settings.`
+            : "Your ChatGPT Bearer token expires in less than 30 minutes. Update it in Settings.";
+          await notify("uso.ai · ChatGPT token expiring soon", body);
+        }
       }
 
-      const results = await Promise.all([
-        creds.claude?.orgId && creds.claude?.sessionKey
-          ? fetchClaudeUsage(creds.claude.orgId, creds.claude.sessionKey)
-          : null,
-        creds.chatgpt?.bearerToken
-          ? fetchChatGPTUsage(creds.chatgpt.bearerToken)
-          : null,
-        creds.cursor?.sessionToken
-          ? fetchCursorUsage(creds.cursor.sessionToken)
-          : null,
-      ]);
+      // Build list of accounts to fetch, in service order
+      const toFetch: { serviceId: string; account: Account; label: string | undefined }[] = [];
+      for (const serviceId of ["claude", "chatgpt", "cursor"]) {
+        const accounts = creds[serviceId] ?? [];
+        const showLabel = accounts.length > 1;
+        for (const account of accounts) {
+          if (isAccountConfigured(serviceId, account)) {
+            toFetch.push({ serviceId, account, label: showLabel ? account.label : undefined });
+          }
+        }
+      }
 
-      // Notify for any expired tokens
-      const expired = results.filter((r) => r?.status === "expired");
-      for (const s of expired) {
-        if (s) await notify(`uso.ai · ${s.name} token expired`, `Your ${s.name} session token has expired. Update it in Settings.`);
+      const settled = await Promise.allSettled(
+        toFetch.map(({ serviceId, account, label }) =>
+          fetchAccount(serviceId, account, label)
+        )
+      );
+
+      const results: ServiceData[] = settled.map((result, i) => {
+        const { serviceId, account, label } = toFetch[i];
+        const serviceName = SERVICES.find((s) => s.id === serviceId)?.name ?? serviceId;
+        if (result.status === "fulfilled") return result.value;
+        return { accountId: account.id, name: serviceName, label, plan: "", status: "error" as const, windows: [] };
+      });
+
+      // Expired-token notifications
+      for (const s of results.filter((r) => r.status === "expired")) {
+        const nameWithLabel = s.label ? `${s.name} · ${s.label}` : s.name;
+        await notify(
+          `uso.ai · ${nameWithLabel} token expired`,
+          `Your ${nameWithLabel} session token has expired. Update it in Settings.`
+        );
       }
 
       setServices(results.filter((r): r is ServiceData => r !== null));
@@ -121,7 +180,7 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
         <>
           <div className="flex gap-3">
             {services.filter((s) => s.status === "ok").map((s) => (
-              <NextResetCard key={s.name} service={s} />
+              <NextResetCard key={s.accountId} service={s} />
             ))}
           </div>
 
@@ -130,7 +189,7 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
               <><SkeletonCard /><SkeletonCard /></>
             ) : (
               services.map((s) => (
-                <ServiceDonutCard key={s.name} service={s} onSettings={onNavigateToSettings} />
+                <ServiceDonutCard key={s.accountId} service={s} onSettings={onNavigateToSettings} />
               ))
             )}
           </div>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -99,11 +99,10 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
       const toFetch: { serviceId: string; account: Account; label: string | undefined }[] = [];
       for (const serviceId of ["claude", "chatgpt", "cursor"]) {
         const accounts = creds[serviceId] ?? [];
-        const showLabel = accounts.length > 1;
-        for (const account of accounts) {
-          if (isAccountConfigured(serviceId, account)) {
-            toFetch.push({ serviceId, account, label: showLabel ? account.label : undefined });
-          }
+        const configuredAccounts = accounts.filter((a) => isAccountConfigured(serviceId, a));
+        const showLabel = configuredAccounts.length > 1;
+        for (const account of configuredAccounts) {
+          toFetch.push({ serviceId, account, label: showLabel ? account.label : undefined });
         }
       }
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect } from "react";
-import { Eye, EyeOff, CheckCircle2, Circle } from "lucide-react";
-import { load } from "@tauri-apps/plugin-store";
+import { Eye, EyeOff, CheckCircle2, Circle, Trash2 } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -8,15 +7,11 @@ import { Button } from "@/components/ui/button";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { ServiceAvatar } from "@/components/ServiceAvatar";
 import { SERVICES } from "@/lib/services";
+import { loadCredentials, saveCredentials } from "@/lib/credentials";
 import { fetchClaudeUsage } from "@/lib/api/claude";
 import { fetchChatGPTUsage } from "@/lib/api/chatgpt";
 import { fetchCursorUsage } from "@/lib/api/cursor";
-
-type Credentials = Record<string, Record<string, string>>;
-
-function isConfigured(creds: Credentials, serviceId: string, fields: { key: string }[]): boolean {
-  return fields.every((f) => !!creds[serviceId]?.[f.key]);
-}
+import type { Account, CredentialsStore } from "@/lib/credentials";
 
 function PasswordInput({
   id, placeholder, value, onChange,
@@ -48,38 +43,92 @@ function PasswordInput({
   );
 }
 
+type StatusMap = Record<string, "idle" | "saving" | "saved" | "expired" | "error">;
+
 type Props = { onSaved?: () => void };
 
+function isAccountConfigured(account: Account, fields: { key: string }[]): boolean {
+  return fields.every((f) => !!account.credentials[f.key]?.trim());
+}
+
+function isServiceConfigured(accounts: Account[], fields: { key: string }[]): boolean {
+  return accounts.some((a) => isAccountConfigured(a, fields));
+}
+
+function isPersistedAccountDeletable(persisted: CredentialsStore, serviceId: string, _accountId: string): boolean {
+  const accounts = persisted[serviceId] ?? [];
+  if (accounts.length !== 1) return true; // multiple accounts — always deletable
+  // Only account: hide delete if it has at least one non-empty credential field
+  const sole = accounts[0];
+  const service = SERVICES.find((s) => s.id === serviceId);
+  const hasAnyField = service?.fields.some((f) => !!sole.credentials[f.key]?.trim()) ?? false;
+  return !hasAnyField; // show delete only if all fields are empty (broken state)
+}
+
 export default function Settings({ onSaved }: Props) {
-  const [credentials, setCredentials] = useState<Credentials>({});
-  const [statuses, setStatuses] = useState<Record<string, "idle" | "saving" | "saved" | "expired" | "error">>({});
+  const [persisted, setPersisted] = useState<CredentialsStore>({});
+  const [draft, setDraft] = useState<CredentialsStore>({});
+  const [statuses, setStatuses] = useState<StatusMap>({});
 
   useEffect(() => {
-    async function loadCreds() {
-      try {
-        const store = await load("credentials.json", { autoSave: false, defaults: {} });
-        const saved = await store.get<Credentials>("credentials");
-        if (saved) setCredentials(saved);
-      } catch (e) {
-        console.error("Failed to load credentials", e);
+    loadCredentials().then((creds) => {
+      // Ensure every service has an array entry
+      const normalized: CredentialsStore = {};
+      for (const s of SERVICES) {
+        normalized[s.id] = creds[s.id] ?? [];
       }
-    }
-    loadCreds();
+      setPersisted(normalized);
+      setDraft(JSON.parse(JSON.stringify(normalized))); // deep copy
+    });
   }, []);
 
-  function handleChange(serviceId: string, fieldKey: string, value: string) {
-    setCredentials((prev) => ({
+  function setAccountField(serviceId: string, accountId: string, key: string, value: string) {
+    setDraft((prev) => ({
       ...prev,
-      [serviceId]: { ...prev[serviceId], [fieldKey]: value },
+      [serviceId]: (prev[serviceId] ?? []).map((a) =>
+        a.id === accountId ? { ...a, credentials: { ...a.credentials, [key]: value } } : a
+      ),
     }));
-    setStatuses((prev) => ({ ...prev, [serviceId]: "idle" }));
+    setStatuses((prev) => ({ ...prev, [accountId]: "idle" }));
   }
 
-  async function handleSave(serviceId: string) {
-    setStatuses((prev) => ({ ...prev, [serviceId]: "saving" }));
+  function setAccountLabel(serviceId: string, accountId: string, value: string) {
+    setDraft((prev) => ({
+      ...prev,
+      [serviceId]: (prev[serviceId] ?? []).map((a) =>
+        a.id === accountId ? { ...a, label: value } : a
+      ),
+    }));
+  }
+
+  function addAccount(serviceId: string) {
+    const current = draft[serviceId] ?? [];
+    const newAccount: Account = {
+      id: crypto.randomUUID(),
+      label: `Account ${current.length + 1}`,
+      credentials: {},
+    };
+    setDraft((prev) => ({ ...prev, [serviceId]: [...(prev[serviceId] ?? []), newAccount] }));
+  }
+
+  async function deleteAccount(serviceId: string, accountId: string) {
+    const isInPersisted = (persisted[serviceId] ?? []).some((a) => a.id === accountId);
+    const newDraft = { ...draft, [serviceId]: (draft[serviceId] ?? []).filter((a) => a.id !== accountId) };
+    setDraft(newDraft);
+    if (isInPersisted) {
+      const newPersisted = { ...persisted, [serviceId]: (persisted[serviceId] ?? []).filter((a) => a.id !== accountId) };
+      await saveCredentials(newPersisted);
+      setPersisted(newPersisted);
+    }
+  }
+
+  async function handleSave(serviceId: string, accountId: string) {
+    setStatuses((prev) => ({ ...prev, [accountId]: "saving" }));
     try {
-      const creds = credentials[serviceId] ?? {};
-      let validationStatus: string = "ok";
+      const account = (draft[serviceId] ?? []).find((a) => a.id === accountId);
+      if (!account) return;
+      const creds = account.credentials;
+      let validationStatus = "ok";
 
       if (serviceId === "claude" && creds.orgId && creds.sessionKey) {
         const result = await fetchClaudeUsage(creds.orgId, creds.sessionKey);
@@ -93,25 +142,25 @@ export default function Settings({ onSaved }: Props) {
       }
 
       if (validationStatus === "expired") {
-        setStatuses((prev) => ({ ...prev, [serviceId]: "expired" }));
+        setStatuses((prev) => ({ ...prev, [accountId]: "expired" }));
         return;
       }
       if (validationStatus === "error") {
-        setStatuses((prev) => ({ ...prev, [serviceId]: "error" }));
+        setStatuses((prev) => ({ ...prev, [accountId]: "error" }));
         return;
       }
 
-      const store = await load("credentials.json", { autoSave: false, defaults: {} });
-      await store.set("credentials", credentials);
-      await store.save();
-      setStatuses((prev) => ({ ...prev, [serviceId]: "saved" }));
+      const newPersisted = { ...persisted, [serviceId]: draft[serviceId] ?? [] };
+      await saveCredentials(newPersisted);
+      setPersisted(newPersisted);
+      setStatuses((prev) => ({ ...prev, [accountId]: "saved" }));
       setTimeout(() => {
-        setStatuses((prev) => ({ ...prev, [serviceId]: "idle" }));
+        setStatuses((prev) => ({ ...prev, [accountId]: "idle" }));
         onSaved?.();
       }, 800);
     } catch (e) {
       console.error("Failed to save credentials", e);
-      setStatuses((prev) => ({ ...prev, [serviceId]: "error" }));
+      setStatuses((prev) => ({ ...prev, [accountId]: "error" }));
     }
   }
 
@@ -127,7 +176,7 @@ export default function Settings({ onSaved }: Props) {
       <Tabs defaultValue="claude">
         <TabsList className="w-full">
           {SERVICES.map((service) => {
-            const configured = isConfigured(credentials, service.id, service.fields);
+            const configured = isServiceConfigured(persisted[service.id] ?? [], service.fields);
             return (
               <TabsTrigger key={service.id} value={service.id} className="flex-1 gap-2">
                 <ServiceAvatar name={service.name} size="sm" />
@@ -142,40 +191,85 @@ export default function Settings({ onSaved }: Props) {
         </TabsList>
 
         {SERVICES.map((service) => {
-          const status = statuses[service.id] ?? "idle";
+          const accounts = draft[service.id] ?? [];
           return (
-            <TabsContent key={service.id} value={service.id} className="mt-4">
-              <Card>
-                <CardContent className="px-6 py-6 space-y-5">
-                  {service.fields.map((field) => (
-                    <div key={field.key} className="space-y-1.5">
-                      <Label htmlFor={`${service.id}-${field.key}`} className="text-xs font-medium">
-                        {field.label}
-                      </Label>
-                      <PasswordInput
-                        id={`${service.id}-${field.key}`}
-                        placeholder={field.placeholder}
-                        value={credentials[service.id]?.[field.key] ?? ""}
-                        onChange={(v) => handleChange(service.id, field.key, v)}
-                      />
-                      <p className="text-xs text-muted-foreground leading-relaxed">{field.hint}</p>
-                    </div>
-                  ))}
+            <TabsContent key={service.id} value={service.id} className="mt-4 space-y-4">
+              {accounts.map((account) => {
+                const status = statuses[account.id] ?? "idle";
+                const isUnsaved = !(persisted[service.id] ?? []).some((a) => a.id === account.id);
+                const showDelete = isUnsaved || isPersistedAccountDeletable(persisted, service.id, account.id);
+                const canSave = service.fields.every((f) => !!account.credentials[f.key]?.trim());
 
-                  <Button
-                    onClick={() => handleSave(service.id)}
-                    className="w-full mt-2"
-                    disabled={status === "saving"}
-                    variant={status === "error" || status === "expired" ? "destructive" : "default"}
-                  >
-                    {status === "saving" && "Validating..."}
-                    {status === "saved" && "✓ Saved"}
-                    {status === "expired" && "Token is expired or invalid"}
-                    {status === "error" && "Failed — check your credentials"}
-                    {status === "idle" && `Save ${service.name} credentials`}
-                  </Button>
-                </CardContent>
-              </Card>
+                return (
+                  <Card key={account.id}>
+                    <CardContent className="px-6 py-6 space-y-5">
+                      {/* Label */}
+                      <div className="space-y-1.5">
+                        <Label htmlFor={`${account.id}-label`} className="text-xs font-medium">
+                          Account label
+                        </Label>
+                        <Input
+                          id={`${account.id}-label`}
+                          placeholder="e.g. Personal, Work"
+                          value={account.label}
+                          onChange={(e) => setAccountLabel(service.id, account.id, e.target.value)}
+                          className="text-xs"
+                        />
+                      </div>
+
+                      {/* Credential fields */}
+                      {service.fields.map((field) => (
+                        <div key={field.key} className="space-y-1.5">
+                          <Label htmlFor={`${account.id}-${field.key}`} className="text-xs font-medium">
+                            {field.label}
+                          </Label>
+                          <PasswordInput
+                            id={`${account.id}-${field.key}`}
+                            placeholder={field.placeholder}
+                            value={account.credentials[field.key] ?? ""}
+                            onChange={(v) => setAccountField(service.id, account.id, field.key, v)}
+                          />
+                          <p className="text-xs text-muted-foreground leading-relaxed">{field.hint}</p>
+                        </div>
+                      ))}
+
+                      {/* Actions */}
+                      <div className="flex items-center gap-3">
+                        <Button
+                          onClick={() => handleSave(service.id, account.id)}
+                          className="flex-1"
+                          disabled={status === "saving" || !canSave}
+                          variant={status === "error" || status === "expired" ? "destructive" : "default"}
+                        >
+                          {status === "saving" && "Validating..."}
+                          {status === "saved" && "✓ Saved"}
+                          {status === "expired" && "Token is expired or invalid"}
+                          {status === "error" && "Failed — check your credentials"}
+                          {(status === "idle") && `Save ${service.name} credentials`}
+                        </Button>
+                        {showDelete && (
+                          <button
+                            type="button"
+                            onClick={() => deleteAccount(service.id, account.id)}
+                            className="text-muted-foreground hover:text-destructive transition-colors"
+                            title="Delete account"
+                          >
+                            <Trash2 size={15} />
+                          </button>
+                        )}
+                      </div>
+                    </CardContent>
+                  </Card>
+                );
+              })}
+
+              <Button
+                variant="outline"
+                className="w-full"
+                onClick={() => addAccount(service.id)}
+              >
+                + Add account
+              </Button>
             </TabsContent>
           );
         })}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -55,11 +55,12 @@ function isServiceConfigured(accounts: Account[], fields: { key: string }[]): bo
   return accounts.some((a) => isAccountConfigured(a, fields));
 }
 
-function isPersistedAccountDeletable(persisted: CredentialsStore, serviceId: string, _accountId: string): boolean {
+function isPersistedAccountDeletable(persisted: CredentialsStore, serviceId: string, accountId: string): boolean {
   const accounts = persisted[serviceId] ?? [];
   if (accounts.length !== 1) return true; // multiple accounts — always deletable
   // Only account: hide delete if it has at least one non-empty credential field
-  const sole = accounts[0];
+  const sole = accounts.find((a) => a.id === accountId);
+  if (!sole) return true;
   const service = SERVICES.find((s) => s.id === serviceId);
   const hasAnyField = service?.fields.some((f) => !!sole.credentials[f.key]?.trim()) ?? false;
   return !hasAnyField; // show delete only if all fields are empty (broken state)

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,9 @@ export type UsageWindow = {
 export type ServiceStatus = "ok" | "expired" | "error" | "not_configured";
 
 export type ServiceData = {
+  accountId: string;
   name: string;
+  label?: string;
   plan: string;
   status: ServiceStatus;
   windows: UsageWindow[];


### PR DESCRIPTION
## Summary

- **Data model migration** — `credentials.json` migrated from flat `{ serviceId: { fields } }` to `{ serviceId: Account[] }`. Migration runs automatically on first load; existing credentials become a single "Default" account with no user action required.
- **Dashboard** — iterates all accounts per service via `Promise.allSettled`. Each account renders as its own `ServiceDonutCard` and `NextResetCard`. Per-account error isolation: one failed fetch doesn't collapse other cards. Service name sourced from `SERVICES` config for lookup correctness.
- **Settings UI** — per-account sections with label field, credential fields, per-account Save (validates against API), Delete (unsaved → draft-only; persisted → immediate store write), and "+ Add account" button. Tab indicator checks persisted state only.
- **Card headers** — show `"Service · Label"` format when a service has multiple accounts; single-account services show just the service name (unchanged from today).
- **Notifications** — expired-token and ChatGPT expiry warnings include account label when multiple accounts exist for the same service.

## Design

Spec: `docs/superpowers/specs/2026-03-14-multi-account-design.md`
Plan: `docs/superpowers/plans/2026-03-14-multi-account.md`

## Files changed

| File | Change |
|------|--------|
| `src/lib/credentials.ts` | New `Account` + `CredentialsStore` types; migration in `loadCredentials`; new `saveCredentials` export |
| `src/types.ts` | `accountId: string` + `label?: string` on `ServiceData` |
| `src/lib/api/claude.ts` | `accountId: ""` placeholder on all returns |
| `src/lib/api/chatgpt.ts` | `accountId: ""` placeholder on all returns |
| `src/lib/api/cursor.ts` | `accountId: ""` placeholder on all returns |
| `src/pages/Dashboard.tsx` | Multi-account fetch loop, `Promise.allSettled`, per-account error handling, updated notifications |
| `src/pages/Settings.tsx` | Full rewrite: persisted+draft state, per-account add/save/delete |
| `src/components/dashboard/ServiceDonutCard.tsx` | Show label in card title |
| `src/components/dashboard/NextResetCard.tsx` | Show label in header |

## Test plan

- [ ] Launch app — existing saved credentials load automatically as "Default" account (migration)
- [ ] Settings: "+ Add account" adds a new section; Save validates and persists; Delete removes
- [ ] Dashboard: two configured accounts for same service render as two separate cards with `"Service · Label"` headers
- [ ] Dashboard: single account shows no label (just service name)
- [ ] One account fetch failing (expired token) shows error card only for that account; other accounts unaffected
- [ ] `npm run build` passes with zero TypeScript errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)