### PR TITLE
chore: commit Cargo.lock

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "tauri-app"
-version = "0.1.0"
+version = "1.1.0"
 dependencies = [
  "serde",
  "serde_json",


### PR DESCRIPTION
`src-tauri/Cargo.lock` was modified during the v1.1.0 build but not staged in the previous PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)