### PR TITLE
fix: handle null resets_at for Claude five_hour window

### DIFF
--- a/src/components/dashboard/NextResetCard.tsx
+++ b/src/components/dashboard/NextResetCard.tsx
@@ -4,7 +4,7 @@ import type { ServiceData } from "@/types";
 
 export function NextResetCard({ service }: { service: ServiceData }) {
   const color = getServiceByName(service.name)?.color ?? "#888";
-  const soonest = service.windows[0] ?? null;
+  const soonest = service.windows.find((w) => w.resetsAt !== "—") ?? service.windows[0] ?? null;
 
   return (
     <Card className="flex-1 min-w-0">

--- a/src/lib/api/claude.ts
+++ b/src/lib/api/claude.ts
@@ -2,11 +2,12 @@ import { fetch } from "@tauri-apps/plugin-http";
 import type { ServiceData } from "@/types";
 
 type ClaudeUsageResponse = {
-  five_hour: { utilization: number; resets_at: string } | null;
-  seven_day: { utilization: number; resets_at: string } | null;
+  five_hour: { utilization: number; resets_at: string | null } | null;
+  seven_day: { utilization: number; resets_at: string | null } | null;
 };
 
-function formatResetTime(isoString: string): string {
+function formatResetTime(isoString: string | null): string {
+  if (!isoString) return "—";
   const date = new Date(isoString);
   const diffMs = date.getTime() - Date.now();
   const diffMins = Math.round(diffMs / 60000);


### PR DESCRIPTION
## Bug

When the Claude API returns `"resets_at": null` for the `five_hour` window (no active session), the app was calling `new Date(null)` which resolves to epoch (Jan 1 1970), producing a reset time of `in -29561952m`.

## Root cause

`ClaudeUsageResponse` typed `resets_at` as `string`, but the API can return `null` when the 5-hour session hasn't started (0% utilization).

## Fix

- Type `resets_at` as `string | null` in `ClaudeUsageResponse`
- Return `"—"` from `formatResetTime` when value is null
- `NextResetCard` now skips windows with `"—"` reset time and picks the first window with a real reset (e.g. Weekly) instead of always using `windows[0]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)