### PR TITLE
feat: background token expiry notifications (3-min and 30-min warnings)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,44 +5,18 @@
 - Multi-service usage dashboard (Claude, ChatGPT, Cursor)
 - Per-service credential management with validation
 - Auto-refresh every 5 min + manual refresh
-- Token expiration warnings (desktop notifications)
 - Dark / Light / System theme toggle
 - Donut chart + progress bar usage visualizations
-
----
-
-## 🚧 In Progress
-
-### Feature 1 — Menu Bar App
-
-Convert uso.ai from a standard window into a persistent macOS menu bar popup.
-
-- Add `tray-icon` feature to Tauri
-- Add `tauri-plugin-global-shortcut` and `tauri-plugin-positioner`
-- Build tray icon — left-click toggles window
-- Position window below tray icon (`TrayCenter`)
-- Register global shortcut `Cmd+Shift+U` to toggle window
-- Hide window on blur (click outside dismisses popup)
-- Window: frameless, hidden by default, no taskbar entry
-- Hide app from macOS Dock (`LSUIElement`)
+- Menu bar app — tray icon, global shortcut `⌘⇧U`, window positioning, no Dock icon
+- Multiple accounts per service — label, add, delete, per-account save
+- Token expiry notifications — background polling every 1 min, 3-min and 30-min thresholds, fires once per token per threshold
+- Quit from tray right-click menu
+- Custom app icon — dark rounded square with "u" lettermark
+- Polished README with demo GIF
 
 ---
 
 ## 📋 Planned
-
-### Feature 3 — Auto Account Detection
-
-Automatically detect credentials from local files — no manual cookie extraction.
-
-- **Cursor** — read `WorkosCursorSessionToken` from Cursor's local SQLite (`globalStorage/state.vscdb`)
-- **Claude (Chrome)** — read `sessionKey` cookie from Chrome's Cookies SQLite + decrypt via macOS Keychain
-- **Claude (Firefox)** — read `sessionKey` cookie from Firefox's unencrypted `cookies.sqlite` (fallback)
-- **Claude org ID** — auto-fetch from `https://claude.ai/api/organizations` once session key is known
-- **ChatGPT** — read bearer token from Chrome/Firefox cookies for `chatgpt.com`
-- **Frontend** — "Auto-detect" button per service in Settings, pre-fills & saves on success
-- **First launch** — silently run all detect commands; skip Settings if credentials found
-
----
 
 ### Feature — Claude Account Info
 
@@ -54,27 +28,17 @@ The Claude card currently shows no email because the correct user-info endpoint 
 
 ---
 
-### Feature — Multiple Accounts Per Service
+### Feature — Auto Account Detection
 
-Power users often have a personal account and a company/team account for the same service (e.g. personal Claude Pro + work Claude Team). Right now credentials are one-per-service.
+Automatically detect credentials from local files — no manual cookie extraction.
 
-- **Data model** — change `credentials.json` schema from `{ claude: { orgId, sessionKey } }` to `{ claude: Account[] }` where each `Account` has a `label`, credentials, and an `active` flag
-- **Settings UI** — allow adding, labeling ("Personal", "Work"), and deleting multiple accounts per service; show which is currently active
-- **Account switcher** — add a small switcher in the dashboard card header or as a dropdown, so users can flip between accounts without going to Settings
-- **Fetch all or active** — decide whether to show usage for only the active account, or aggregate all accounts for the same service side by side
-- **Migration** — auto-migrate existing single-account credentials to the new array format on first launch after update
-
----
-
-### Feature — Token Expiry Desktop Notifications
-
-The infra for notifications already exists (`notify.ts`, `expiresWithin()`), but coverage is incomplete and the UX is passive (only fires at fetch time, not proactively).
-
-- **Background polling** — run a lightweight timer (e.g. every 10 min) that checks token expiry independently of the usage fetch cycle, so users get warned even if they haven't opened the popup recently
-- **Smarter thresholds** — warn at 24h, 2h, and 30min remaining rather than only 30min; each threshold fires only once per session (use a `Set` of already-notified tokens)
-- **Claude session key** — the `sessionKey` is not a JWT so expiry can't be decoded client-side; detect expiry by catching 401 responses and notify immediately
-- **Cursor session token** — same issue as Claude; detect via API response status
-- **Actionable notification** — include a "Open Settings" deep-link in the notification body so users can update the token in one click
+- **Cursor** — read `WorkosCursorSessionToken` from Cursor's local SQLite (`globalStorage/state.vscdb`)
+- **Claude (Chrome)** — read `sessionKey` cookie from Chrome's Cookies SQLite + decrypt via macOS Keychain
+- **Claude (Firefox)** — read `sessionKey` cookie from Firefox's unencrypted `cookies.sqlite` (fallback)
+- **Claude org ID** — auto-fetch from `https://claude.ai/api/organizations` once session key is known
+- **ChatGPT** — read bearer token from Chrome/Firefox cookies for `chatgpt.com`
+- **Frontend** — "Auto-detect" button per service in Settings, pre-fills & saves on success
+- **First launch** — silently run all detect commands; skip Settings if credentials found
 
 ---
 
@@ -91,7 +55,7 @@ Build a companion browser extension (Chrome/Firefox/Safari) that:
 - No user action needed after the one-time extension install
 
 **Option B — macOS Keychain + Browser Cookie DB (no extension needed)**
-Already planned as Feature 3 (Auto Account Detection). Reads directly from:
+Already planned as Auto Account Detection above. Reads directly from:
 
 - Chrome's encrypted `Cookies` SQLite (decrypts via macOS Keychain `Chrome Safe Storage`)
 - Firefox's plain `cookies.sqlite`
@@ -106,21 +70,14 @@ Open a Tauri WebView pointed at the service's login page:
 - Works for all services without a browser extension
 - Downside: complex OAuth/cookie interception; some services use CORS protections
 
-**Recommended path:** Start with Option B (already in progress as Feature 3), then build Option A (browser extension) as a premium experience. Option C is a long-term stretch goal.
+**Recommended path:** Start with Option B (Auto Account Detection), then build Option A (browser extension) as a premium experience. Option C is a long-term stretch goal.
 
 ---
 
 ### Future Ideas
 
-- **More services** — Copilot, Windsurf, Gemini, Codex (currently tracked by OpenUsage.ai)
+- **More services** — Copilot, Windsurf, Gemini
 - **Usage history** — store snapshots locally (SQLite), show trend charts over time
-- **Proactive alerts** — notify when usage is accelerating faster than normal (not just on expiry)
+- **Proactive alerts** — notify when usage is accelerating faster than normal
 - **Auto-updater** — Tauri updater plugin so users get new versions automatically
-
----
-
-### Marketing & Presence
-
-- **README** — a polished GitHub README with screenshots, feature list, install instructions, and a demo GIF
-- **Marketing website** — simple landing page for uso.ai with hero section, feature highlights, download button, and screenshots
-
+- **Marketing website** — landing page with hero, feature highlights, download button, screenshots

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { RefreshCw } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
 import { loadCredentials } from "@/lib/credentials";
@@ -7,7 +7,7 @@ import { fetchChatGPTUsage } from "@/lib/api/chatgpt";
 import { fetchCursorUsage } from "@/lib/api/cursor";
 import { NextResetCard } from "@/components/dashboard/NextResetCard";
 import { ServiceDonutCard } from "@/components/dashboard/ServiceDonutCard";
-import { notify, expiresWithin } from "@/lib/notify";
+import { notify, getJwtExpiry } from "@/lib/notify";
 import { SERVICES } from "@/lib/services";
 import type { Account, CredentialsStore } from "@/lib/credentials";
 import type { ServiceData } from "@/types";
@@ -71,29 +71,52 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  // Tracks which (token prefix + threshold) combos have already fired a notification
+  const notifiedRef = useRef<Set<string>>(new Set());
+
+  // Background expiry check — runs every minute, independently of the 5-min usage fetch
+  const checkExpiry = useCallback(async () => {
+    const creds: CredentialsStore = await loadCredentials();
+    const chatgptAccounts = creds.chatgpt ?? [];
+    const isMulti = chatgptAccounts.length > 1;
+
+    for (let i = 0; i < chatgptAccounts.length; i++) {
+      const acc = chatgptAccounts[i];
+      const token = acc.credentials.bearerToken;
+      if (!token) continue;
+
+      const expiry = getJwtExpiry(token);
+      if (!expiry) continue;
+
+      const minsLeft = Math.round((expiry.getTime() - Date.now()) / 60000);
+      const displayLabel = isMulti ? (acc.label.trim() || `Account ${i + 1}`) : null;
+      const prefix = token.slice(-16); // use last 16 chars as a stable key
+
+      // 3-minute warning
+      if (minsLeft <= 3 && minsLeft > 0 && !notifiedRef.current.has(`${prefix}-3`)) {
+        notifiedRef.current.add(`${prefix}-3`);
+        const body = displayLabel
+          ? `Your ChatGPT (Codex) · ${displayLabel} Bearer token expires in ${minsLeft} minute${minsLeft === 1 ? "" : "s"}. Update it in Settings now.`
+          : `Your ChatGPT Bearer token expires in ${minsLeft} minute${minsLeft === 1 ? "" : "s"}. Update it in Settings now.`;
+        await notify("uso.ai · ChatGPT token expiring soon", body);
+      }
+
+      // 30-minute early warning
+      if (minsLeft <= 30 && minsLeft > 3 && !notifiedRef.current.has(`${prefix}-30`)) {
+        notifiedRef.current.add(`${prefix}-30`);
+        const body = displayLabel
+          ? `Your ChatGPT (Codex) · ${displayLabel} Bearer token expires in less than 30 minutes. Update it in Settings.`
+          : "Your ChatGPT Bearer token expires in less than 30 minutes. Update it in Settings.";
+        await notify("uso.ai · ChatGPT token expiring soon", body);
+      }
+    }
+  }, []);
 
   const fetchAll = useCallback(async () => {
     setLoading(true);
     setFetchError(null);
     try {
       const creds: CredentialsStore = await loadCredentials();
-
-      // ChatGPT pre-fetch expiry warning
-      const chatgptAccounts = creds.chatgpt ?? [];
-      const isMultiChatGPT = chatgptAccounts.length > 1;
-      for (let i = 0; i < chatgptAccounts.length; i++) {
-        const acc = chatgptAccounts[i];
-        const token = acc.credentials.bearerToken;
-        if (token && expiresWithin(token, 30)) {
-          const displayLabel = isMultiChatGPT
-            ? (acc.label.trim() || `Account ${i + 1}`)
-            : null;
-          const body = displayLabel
-            ? `Your ChatGPT (Codex) · ${displayLabel} Bearer token expires in less than 30 minutes. Update it in Settings.`
-            : "Your ChatGPT Bearer token expires in less than 30 minutes. Update it in Settings.";
-          await notify("uso.ai · ChatGPT token expiring soon", body);
-        }
-      }
 
       // Build list of accounts to fetch, in service order
       const toFetch: { serviceId: string; account: Account; label: string | undefined }[] = [];
@@ -140,9 +163,16 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
 
   useEffect(() => {
     fetchAll();
-    const interval = setInterval(fetchAll, 5 * 60 * 1000);
-    return () => clearInterval(interval);
-  }, [fetchAll]);
+    const fetchInterval = setInterval(fetchAll, 5 * 60 * 1000);
+
+    checkExpiry();
+    const expiryInterval = setInterval(checkExpiry, 60 * 1000);
+
+    return () => {
+      clearInterval(fetchInterval);
+      clearInterval(expiryInterval);
+    };
+  }, [fetchAll, checkExpiry]);
 
   return (
     <div className="space-y-3">


### PR DESCRIPTION
## Summary

Adds a 1-minute background timer that checks ChatGPT JWT expiry independently of the 5-min usage fetch, so users get warned even if they haven't opened the popup.

- **3 minutes left** → urgent notification with exact minutes remaining
- **30 minutes left** → early heads-up notification
- Each threshold fires only once per token (tracked via `Set`) — no repeated spam
- Multi-account setups include the account label in the notification body

## Notes

Only ChatGPT tokens are JWTs and can be decoded client-side. Claude and Cursor tokens are opaque session cookies — expiry is detected via 401 responses only (existing behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)