### PR TITLE
feat: usage history — daily snapshots and bar chart on dashboard

### DIFF
--- a/docs/superpowers/plans/2026-03-16-usage-history.md
+++ b/docs/superpowers/plans/2026-03-16-usage-history.md
@@ -1,0 +1,596 @@
+# Usage History Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a History tab to uso.ai that stores one daily usage snapshot per account and renders a grouped bar chart with 7d / 30d / All time ranges and per-service + per-account selection.
+
+**Architecture:** A new `src/lib/history.ts` module handles all read/write to `history.json` via `tauri-plugin-store` (same pattern as `credentials.ts`). `Dashboard.tsx` calls `saveHistorySnapshot` after each successful fetch, using the `toFetch` array to supply `serviceId`. A new `src/pages/History.tsx` page reads history, filters by service/account/range, groups into time buckets, and renders a Recharts `BarChart`. `App.tsx` gains a third nav tab.
+
+**Tech Stack:** `tauri-plugin-store`, `recharts` (already installed at ^3.8.0), React, TypeScript, Tailwind, shadcn/ui
+
+---
+
+## File Map
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/lib/history.ts` | **Create** | `HistorySnapshot` type, `loadHistory`, `saveHistorySnapshot` |
+| `src/pages/History.tsx` | **Create** | History page — service/account/range selectors + chart |
+| `src/pages/Dashboard.tsx` | **Modify** | Call `saveHistorySnapshot` after successful fetch |
+| `src/App.tsx` | **Modify** | Add `"history"` page, History nav tab, render `<History />` |
+
+---
+
+## Task 1: History storage module
+
+**Files:**
+- Create: `src/lib/history.ts`
+
+- [ ] **Step 1: Create `src/lib/history.ts`**
+
+```ts
+import { load } from "@tauri-apps/plugin-store";
+import type { ServiceData } from "@/types";
+
+export type HistorySnapshot = {
+  timestamp: string;   // "YYYY-MM-DD"
+  serviceId: string;   // "claude" | "chatgpt" | "cursor"
+  accountId: string;
+  data: ServiceData;
+};
+
+export async function loadHistory(): Promise<HistorySnapshot[]> {
+  const store = await load("history.json", { autoSave: false, defaults: {} });
+  return (await store.get<HistorySnapshot[]>("history")) ?? [];
+}
+
+export async function saveHistorySnapshot(
+  serviceId: string,
+  data: ServiceData
+): Promise<void> {
+  const store = await load("history.json", { autoSave: false, defaults: {} });
+  const history = (await store.get<HistorySnapshot[]>("history")) ?? [];
+  const today = new Date().toISOString().slice(0, 10); // "YYYY-MM-DD"
+
+  const exists = history.some(
+    (s) =>
+      s.timestamp === today &&
+      s.serviceId === serviceId &&
+      s.accountId === data.accountId
+  );
+  if (exists) return;
+
+  history.push({ timestamp: today, serviceId, accountId: data.accountId, data });
+  await store.set("history", history);
+  await store.save();
+}
+```
+
+- [ ] **Step 2: Verify TypeScript compiles**
+
+```bash
+npm run build
+```
+
+Expected: `✓ built` with no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/lib/history.ts
+git commit -m "feat: add history storage module (loadHistory, saveHistorySnapshot)"
+```
+
+---
+
+## Task 2: Wire snapshot saving into Dashboard
+
+**Files:**
+- Modify: `src/pages/Dashboard.tsx`
+
+- [ ] **Step 1: Import `saveHistorySnapshot`**
+
+Add to the imports at the top of `src/pages/Dashboard.tsx`:
+
+```ts
+import { saveHistorySnapshot } from "@/lib/history";
+```
+
+- [ ] **Step 2: Call `saveHistorySnapshot` after successful fetch**
+
+In `fetchAll`, find the block that sets services (after `setServices(...)`). Add the snapshot loop immediately after — it uses `settled` and `toFetch` which are still in scope:
+
+```ts
+setServices(results.filter((r): r is ServiceData => r !== null));
+setLastUpdated(new Date());
+
+// Save one snapshot per account per day (silently, non-blocking)
+for (let i = 0; i < settled.length; i++) {
+  const result = settled[i];
+  if (result.status === "fulfilled" && result.value.status === "ok") {
+    saveHistorySnapshot(toFetch[i].serviceId, result.value).catch(() => {});
+  }
+}
+```
+
+Note: `.catch(() => {})` ensures a storage failure never surfaces as a UI error.
+
+- [ ] **Step 3: Verify build**
+
+```bash
+npm run build
+```
+
+Expected: `✓ built` with no errors.
+
+- [ ] **Step 4: Smoke test**
+
+Run `npm run tauri dev`, open the app, trigger a refresh. Then check the store file exists:
+
+```bash
+ls ~/Library/Application\ Support/com.tauri.dev/history.json 2>/dev/null || \
+ls ~/Library/Application\ Support/uso-ai/history.json 2>/dev/null || \
+echo "check ~/Library/Application Support/ for history.json"
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pages/Dashboard.tsx
+git commit -m "feat: save daily usage snapshot after each successful fetch"
+```
+
+---
+
+## Task 3: History page component
+
+**Files:**
+- Create: `src/pages/History.tsx`
+
+This is the largest task. Build it in sub-steps.
+
+### 3a — Data helpers
+
+- [ ] **Step 1: Create `src/pages/History.tsx` with data-processing helpers only (no JSX yet)**
+
+```ts
+import { useState, useEffect } from "react";
+import { loadHistory, type HistorySnapshot } from "@/lib/history";
+import { SERVICES } from "@/lib/services";
+import { loadCredentials } from "@/lib/credentials";
+
+// ── Time range ────────────────────────────────────────────────────────────────
+
+type Range = "7d" | "30d" | "all";
+
+function cutoffDate(range: Range): Date | null {
+  if (range === "all") return null;
+  const d = new Date();
+  d.setDate(d.getDate() - (range === "7d" ? 7 : 30));
+  return d;
+}
+
+function filterByRange(snapshots: HistorySnapshot[], range: Range): HistorySnapshot[] {
+  const cutoff = cutoffDate(range);
+  if (!cutoff) return snapshots;
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  return snapshots.filter((s) => s.timestamp >= cutoffStr);
+}
+
+// ── Time bucket ───────────────────────────────────────────────────────────────
+
+// Parse "YYYY-MM-DD" as local midnight to avoid UTC off-by-one in non-UTC timezones
+function parseLocalDate(dateStr: string): Date {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+function bucketKey(timestamp: string, range: Range): string {
+  if (range === "7d") return timestamp; // "YYYY-MM-DD"
+  if (range === "30d") {
+    // ISO week start (Monday), using local date parsing
+    const d = parseLocalDate(timestamp);
+    const day = d.getDay(); // 0=Sun
+    const diff = day === 0 ? -6 : 1 - day;
+    d.setDate(d.getDate() + diff);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  }
+  // all → "YYYY-MM"
+  return timestamp.slice(0, 7);
+}
+
+function bucketLabel(key: string, range: Range): string {
+  if (range === "7d") {
+    return parseLocalDate(key).toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+  }
+  if (range === "30d") {
+    return parseLocalDate(key).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  }
+  // all → "Mar 2026"
+  const [year, month] = key.split("-");
+  return new Date(Number(year), Number(month) - 1).toLocaleDateString("en-US", { month: "short", year: "numeric" });
+}
+
+// ── Chart data ────────────────────────────────────────────────────────────────
+
+type ChartRow = { bucket: string; [windowLabel: string]: number | string };
+
+// Generate all expected bucket keys for the range (for placeholder bars)
+function allBucketKeys(range: Range): string[] {
+  if (range === "all") return []; // unbounded — no placeholders for "all"
+  const days = range === "7d" ? 7 : 30;
+  const keys = new Set<string>();
+  for (let i = 0; i < days; i++) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    const ts = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    keys.add(bucketKey(ts, range));
+  }
+  return Array.from(keys).sort();
+}
+
+function buildChartData(
+  snapshots: HistorySnapshot[],
+  range: Range,
+  knownWindowLabels: string[]
+): ChartRow[] {
+  // Group snapshots by bucket key, keeping the latest per bucket
+  const byBucket = new Map<string, HistorySnapshot>();
+  for (const s of snapshots) {
+    const key = bucketKey(s.timestamp, range);
+    const existing = byBucket.get(key);
+    if (!existing || s.timestamp > existing.timestamp) {
+      byBucket.set(key, s);
+    }
+  }
+
+  // Fill in placeholder rows for empty buckets (7d/30d only)
+  const placeholderKeys = allBucketKeys(range).filter((k) => !byBucket.has(k));
+  const allKeys = [
+    ...Array.from(byBucket.keys()),
+    ...placeholderKeys,
+  ].sort((a, b) => a.localeCompare(b));
+
+  return allKeys.map((key) => {
+    const snap = byBucket.get(key);
+    const row: ChartRow = { bucket: bucketLabel(key, range) };
+    for (const label of knownWindowLabels) {
+      row[label] = snap ? (snap.data.windows.find((w) => w.label === label)?.usedPercent ?? 0) : 0;
+    }
+    return row;
+  });
+}
+
+// Collect all unique window labels from a snapshot set
+function windowLabels(snapshots: HistorySnapshot[]): string[] {
+  const labels = new Set<string>();
+  for (const s of snapshots) {
+    for (const w of s.data.windows) labels.add(w.label);
+  }
+  return Array.from(labels);
+}
+```
+
+- [ ] **Step 2: Verify build**
+
+```bash
+npm run build
+```
+
+Expected: `✓ built`
+
+### 3b — Component shell with selectors
+
+- [ ] **Step 3: Add the component shell (state + service/account/range selectors) after the helpers**
+
+```tsx
+export default function History() {
+  const [allSnapshots, setAllSnapshots] = useState<HistorySnapshot[]>([]);
+  const [configuredServiceIds, setConfiguredServiceIds] = useState<string[]>([]);
+  const [selectedService, setSelectedService] = useState<string>("");
+  const [selectedAccountId, setSelectedAccountId] = useState<string>("");
+  const [range, setRange] = useState<Range>("7d");
+
+  // Load history + configured services on mount
+  useEffect(() => {
+    Promise.all([loadHistory(), loadCredentials()]).then(([history, creds]) => {
+      setAllSnapshots(history);
+      const configured = SERVICES
+        .filter((s) => (creds[s.id] ?? []).some((a) => Object.values(a.credentials).some((v) => v.trim())))
+        .map((s) => s.id);
+      setConfiguredServiceIds(configured);
+      if (configured.length > 0 && !selectedService) {
+        setSelectedService(configured[0]);
+      }
+    });
+  }, []);
+
+  // When service changes, default to first account
+  useEffect(() => {
+    if (!selectedService) return;
+    const accountIds = [...new Set(
+      allSnapshots.filter((s) => s.serviceId === selectedService).map((s) => s.accountId)
+    )];
+    setSelectedAccountId(accountIds[0] ?? "");
+  }, [selectedService, allSnapshots]);
+
+  // Derive chart data
+  const serviceSnapshots = allSnapshots.filter(
+    (s) => s.serviceId === selectedService && s.accountId === selectedAccountId
+  );
+  const rangeFiltered = filterByRange(serviceSnapshots, range);
+  const windowKeys = windowLabels(rangeFiltered);
+  const chartData = buildChartData(rangeFiltered, range, windowKeys);
+
+  // Account tabs: only show if >1 account has snapshots for this service
+  const accountIds = [...new Set(
+    allSnapshots.filter((s) => s.serviceId === selectedService).map((s) => s.accountId)
+  )];
+  const showAccountTabs = accountIds.length > 1;
+
+  const serviceColor = SERVICES.find((s) => s.id === selectedService)?.color ?? "#888";
+
+  return (
+    <div className="space-y-3">
+      {/* Service tabs */}
+      <div className="flex gap-1">
+        {configuredServiceIds.map((id) => {
+          const svc = SERVICES.find((s) => s.id === id)!;
+          return (
+            <button
+              key={id}
+              onClick={() => setSelectedService(id)}
+              className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+                selectedService === id
+                  ? "text-white"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+              style={selectedService === id ? { backgroundColor: serviceColor } : {}}
+            >
+              {svc.name}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Account tabs (only if >1 account) */}
+      {showAccountTabs && (
+        <div className="flex gap-1">
+          {accountIds.map((id) => {
+            const label = allSnapshots.find(
+              (s) => s.serviceId === selectedService && s.accountId === id
+            )?.data.label ?? id.slice(0, 8);
+            return (
+              <button
+                key={id}
+                onClick={() => setSelectedAccountId(id)}
+                className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+                  selectedAccountId === id
+                    ? "bg-secondary text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Time range selector */}
+      <div className="flex gap-1">
+        {(["7d", "30d", "all"] as Range[]).map((r) => (
+          <button
+            key={r}
+            onClick={() => setRange(r)}
+            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              range === r
+                ? "bg-secondary text-foreground"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {r === "all" ? "All" : r}
+          </button>
+        ))}
+      </div>
+
+      {/* Chart or empty state */}
+      {chartData.length === 0 ? (
+        <p className="text-center text-sm text-muted-foreground py-12">
+          No history yet. Usage is recorded once per day.
+        </p>
+      ) : (
+        <HistoryChart
+          data={chartData}
+          windowKeys={windowKeys}
+          color={serviceColor}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+### 3c — Chart sub-component
+
+- [ ] **Step 5: Add the `HistoryChart` component above `export default function History()`**
+
+```tsx
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+
+// Slightly lighter shade for secondary bars
+function lighten(hex: string, amount = 0.35): string {
+  const num = parseInt(hex.replace("#", ""), 16);
+  const r = Math.min(255, Math.round(((num >> 16) & 0xff) + 255 * amount));
+  const g = Math.min(255, Math.round(((num >> 8) & 0xff) + 255 * amount));
+  const b = Math.min(255, Math.round((num & 0xff) + 255 * amount));
+  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+}
+
+function HistoryChart({
+  data,
+  windowKeys,
+  color,
+}: {
+  data: ChartRow[];
+  windowKeys: string[];
+  color: string;
+}) {
+  const colors = [color, lighten(color)];
+
+  return (
+    <ResponsiveContainer width="100%" height={180}>
+      <BarChart data={data} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+        <XAxis
+          dataKey="bucket"
+          tick={{ fontSize: 10 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <YAxis
+          domain={[0, 100]}
+          tickFormatter={(v) => `${v}%`}
+          tick={{ fontSize: 10 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <Tooltip
+          formatter={(value: number, name: string) => [`${value}%`, name]}
+          contentStyle={{ fontSize: 11, borderRadius: 8 }}
+        />
+        {windowKeys.length > 1 && (
+          <Legend wrapperStyle={{ fontSize: 11, paddingTop: 4 }} />
+        )}
+        {windowKeys.map((key, i) => (
+          <Bar key={key} dataKey={key} fill={colors[i % colors.length]} radius={[3, 3, 0, 0]} maxBarSize={28} />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+```
+
+- [ ] **Step 6: Verify build**
+
+```bash
+npm run build
+```
+
+Expected: `✓ built` with no errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pages/History.tsx
+git commit -m "feat: add History page with bar chart, service/account/range selectors"
+```
+
+---
+
+## Task 4: Wire History tab into App
+
+**Files:**
+- Modify: `src/App.tsx`
+
+- [ ] **Step 1: Add History import and update Page type**
+
+At the top of `src/App.tsx`, add:
+
+```ts
+import History from "@/pages/History";
+import { History as HistoryIcon } from "lucide-react";
+```
+
+Change the `Page` type:
+
+```ts
+type Page = "dashboard" | "settings" | "history";
+```
+
+- [ ] **Step 2: Add History nav button**
+
+In the header nav (after the Settings button), add:
+
+```tsx
+<button
+  onClick={() => setPage("history")}
+  className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+    page === "history"
+      ? "text-white"
+      : "text-muted-foreground hover:text-foreground"
+  }`}
+  style={page === "history" ? { backgroundColor: "#1a1a1a" } : {}}
+  title="History"
+>
+  <HistoryIcon size={13} />
+  History
+</button>
+```
+
+- [ ] **Step 3: Render History page**
+
+In the page content section, update the conditional render:
+
+```tsx
+{page === "dashboard" ? (
+  <Dashboard onNavigateToSettings={() => setPage("settings")} />
+) : page === "settings" ? (
+  <Settings onSaved={() => setPage("dashboard")} />
+) : (
+  <History />
+)}
+```
+
+- [ ] **Step 4: Verify build**
+
+```bash
+npm run build
+```
+
+Expected: `✓ built` with no errors.
+
+- [ ] **Step 5: Smoke test**
+
+```bash
+npm run tauri dev
+```
+
+- Open the app — verify three nav tabs: Dashboard, Settings, History
+- Click History — should show "No history yet" if no snapshots exist, or a chart if snapshots were saved in Task 2
+- Trigger a refresh from Dashboard, then return to History — a snapshot should appear
+- Try switching services, time ranges
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/App.tsx
+git commit -m "feat: add History tab to app navigation"
+```
+
+---
+
+## Task 5: Final check and PR
+
+- [ ] **Step 1: Full build**
+
+```bash
+npm run build
+```
+
+Expected: `✓ built` with no TypeScript errors.
+
+- [ ] **Step 2: Push and open PR**
+
+```bash
+git push
+gh pr create --title "feat: usage history tab with daily snapshots and bar chart" \
+  --body "Adds a History tab that records one daily usage snapshot per account and renders a grouped bar chart. Service/account/range selectors. No new dependencies — recharts was already installed."
+```

--- a/docs/superpowers/specs/2026-03-16-usage-history-design.md
+++ b/docs/superpowers/specs/2026-03-16-usage-history-design.md
@@ -1,0 +1,127 @@
+# Usage History — Design Spec
+
+**Date:** 2026-03-16
+**Status:** Approved
+
+---
+
+## Overview
+
+Add a Usage History tab to uso.ai so users can see how their AI subscription usage has trended over time. History is stored locally, never synced, and captured once per day per account.
+
+---
+
+## Data Model
+
+A new `history.json` store (via `tauri-plugin-store`, already installed) holds an array of snapshots:
+
+```ts
+type HistorySnapshot = {
+  timestamp: string;  // ISO date string, e.g. "2026-03-16"
+  serviceId: string;  // "claude" | "chatgpt" | "cursor"
+  accountId: string;
+  data: ServiceData;  // full snapshot — windows, plan, email, status
+};
+
+type HistoryStore = HistorySnapshot[];
+```
+
+- One snapshot per `(date, accountId)` pair — duplicates are skipped
+- Snapshots are never auto-purged (a future "Clear history" button can handle this)
+- Full `ServiceData` is stored to maximise flexibility for future analysis
+
+---
+
+## Snapshot Logic
+
+A new `src/lib/history.ts` module exposes:
+
+```ts
+export async function saveHistorySnapshot(serviceId: string, data: ServiceData): Promise<void>
+export async function loadHistory(): Promise<HistoryStore>
+```
+
+`saveHistorySnapshot` runs after each successful `fetchAll` in `Dashboard.tsx`, once per account with `status: "ok"`. It:
+
+1. Loads `history.json`
+2. Checks if a snapshot for `today + accountId` already exists — skips if so
+3. Appends the new snapshot and saves
+
+This is called silently after `setServices()` — no effect on load time or UI feedback.
+
+---
+
+## UI
+
+### Navigation
+
+A third **History** tab is added to the header nav alongside Dashboard and Settings.
+
+### History Page Layout
+
+```
+[ Claude ] [ ChatGPT ] [ Cursor ]     ← service tabs (only configured services)
+[ Personal ] [ Work ]                  ← account tabs (only shown if >1 account)
+
+[ 7d ] [ 30d ] [ All ]                ← time range selector
+
+  ▓▓▓░  ▓▓░░  ▓▓▓▓  ▓░░░             ← grouped bar chart
+  Mon   Tue   Wed   Thu               ← x-axis labels (auto granularity)
+
+  ■ Current session  ■ Weekly         ← legend (one entry per usage window)
+```
+
+### Chart
+
+- **Library:** Recharts
+- **Type:** Grouped bar chart — one group per time bucket, one bar per usage window
+- **Colors:** Service brand color (same palette used in Dashboard cards)
+- **Granularity (auto):**
+  - 7d → one group per day
+  - 30d → one group per week
+  - All → one group per month
+- **Empty days:** Faint placeholder bar at 0% so the x-axis remains consistent
+- **Y-axis:** 0–100% usage
+
+### Service & Account Selection
+
+- Service tabs show only configured services
+- Account tabs appear below service tabs only when the selected service has more than one configured account
+
+### Time Range
+
+Three buttons: `7d` | `30d` | `All` — filters the snapshots passed to the chart.
+
+---
+
+## Files
+
+| File | Change |
+|---|---|
+| `src/lib/history.ts` | New — `saveHistorySnapshot`, `loadHistory` |
+| `src/pages/History.tsx` | New — full History page component |
+| `src/pages/Dashboard.tsx` | Call `saveHistorySnapshot` after successful fetch |
+| `src/App.tsx` | Add History tab to nav, render `<History />` page |
+| `src-tauri/capabilities/*.json` | No changes needed (store plugin already permitted) |
+
+### Dependencies
+
+- Add `recharts` to `package.json`
+
+---
+
+## Edge Cases
+
+- **No history yet:** Show an empty state — "No history yet. Usage is recorded once per day."
+- **Service not configured:** Tab is hidden; no snapshots saved for that service
+- **Account deleted:** Orphaned snapshots remain in storage but are never shown (accountId no longer matches any configured account)
+- **Status not "ok":** Expired/error snapshots are not saved
+
+---
+
+## Out of Scope
+
+- Exporting history (CSV, JSON)
+- Clearing history (future "Clear history" button)
+- Cross-device sync
+- Aggregating multiple accounts into a single chart view

--- a/docs/superpowers/specs/2026-03-16-usage-history-design.md
+++ b/docs/superpowers/specs/2026-03-16-usage-history-design.md
@@ -44,10 +44,12 @@ export async function loadHistory(): Promise<HistoryStore>
 `saveHistorySnapshot` runs after each successful `fetchAll` in `Dashboard.tsx`, once per account with `status: "ok"`. It:
 
 1. Loads `history.json`
-2. Checks if a snapshot for `today + accountId` already exists — skips if so
+2. Checks if a snapshot for `(today, serviceId, accountId)` already exists — skips if so
 3. Appends the new snapshot and saves
 
-This is called silently after `setServices()` — no effect on load time or UI feedback.
+`Dashboard.tsx` must preserve the `(serviceId, ServiceData)` mapping from the `toFetch` array through to the `saveHistorySnapshot` call. The `services` state alone is insufficient — it carries no `serviceId` field. The save loop iterates the fulfilled results from `Promise.allSettled`, which already has `serviceId` in scope.
+
+This is called silently after `setServices()`. Storage grows at ~3–6 entries/day; at that rate, a year of history is ~1,000–2,000 entries — well within the performance envelope of `tauri-plugin-store`. A future "Clear history" button can address long-term growth.
 
 ---
 
@@ -78,7 +80,7 @@ A third **History** tab is added to the header nav alongside Dashboard and Setti
 - **Colors:** Service brand color (same palette used in Dashboard cards)
 - **Granularity (auto):**
   - 7d → one group per day
-  - 30d → one group per week
+  - 30d → one group per week (labeled by week start date, e.g. "Mar 10"); partial edge weeks at the boundary of the 30-day window are shown as-is with their start date — bar height reflects the raw usage % of whichever snapshot falls in that partial week
   - All → one group per month
 - **Empty days:** Faint placeholder bar at 0% so the x-axis remains consistent
 - **Y-axis:** 0–100% usage
@@ -106,7 +108,7 @@ Three buttons: `7d` | `30d` | `All` — filters the snapshots passed to the char
 
 ### Dependencies
 
-- Add `recharts` to `package.json`
+- `recharts` is already installed (`^3.8.0` in `package.json`) — no new dependency needed
 
 ---
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { LayoutDashboard, Settings as SettingsIcon, Sun, Moon, Monitor } from "lucide-react";
+import { LayoutDashboard, Settings as SettingsIcon, Sun, Moon, Monitor, History as HistoryIcon } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import Dashboard from "@/pages/Dashboard";
 import Settings from "@/pages/Settings";
+import History from "@/pages/History";
 import { useTheme } from "@/lib/useTheme";
 import type { Theme } from "@/lib/useTheme";
 
@@ -14,7 +15,7 @@ const THEME_ICONS: Record<Theme, React.ReactNode> = {
   system: <Monitor size={13} />,
 };
 
-type Page = "dashboard" | "settings";
+type Page = "dashboard" | "settings" | "history";
 
 export default function App() {
   const [page, setPage] = useState<Page>("dashboard");
@@ -110,6 +111,19 @@ export default function App() {
             <SettingsIcon size={13} />
             Settings
           </button>
+          <button
+            onClick={() => setPage("history")}
+            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              page === "history"
+                ? "text-white"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+            style={page === "history" ? { backgroundColor: "#1a1a1a" } : {}}
+            title="History"
+          >
+            <HistoryIcon size={13} />
+            History
+          </button>
         </div>
       </div>
 
@@ -119,8 +133,10 @@ export default function App() {
       <div className="flex-1 overflow-y-auto px-5 py-4">
         {page === "dashboard" ? (
           <Dashboard onNavigateToSettings={() => setPage("settings")} />
-        ) : (
+        ) : page === "settings" ? (
           <Settings onSaved={() => setPage("dashboard")} />
+        ) : (
+          <History />
         )}
       </div>
     </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,10 @@
 import { useState, useEffect, useRef } from "react";
 import { invoke } from "@tauri-apps/api/core";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { LayoutDashboard, Settings as SettingsIcon, Sun, Moon, Monitor, History as HistoryIcon } from "lucide-react";
+import { LayoutDashboard, Settings as SettingsIcon, Sun, Moon, Monitor } from "lucide-react";
 import { Separator } from "@/components/ui/separator";
 import Dashboard from "@/pages/Dashboard";
 import Settings from "@/pages/Settings";
-import History from "@/pages/History";
 import { useTheme } from "@/lib/useTheme";
 import type { Theme } from "@/lib/useTheme";
 
@@ -15,7 +14,7 @@ const THEME_ICONS: Record<Theme, React.ReactNode> = {
   system: <Monitor size={13} />,
 };
 
-type Page = "dashboard" | "settings" | "history";
+type Page = "dashboard" | "settings";
 
 export default function App() {
   const [page, setPage] = useState<Page>("dashboard");
@@ -111,19 +110,6 @@ export default function App() {
             <SettingsIcon size={13} />
             Settings
           </button>
-          <button
-            onClick={() => setPage("history")}
-            className={`flex items-center gap-1.5 px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
-              page === "history"
-                ? "text-white"
-                : "text-muted-foreground hover:text-foreground"
-            }`}
-            style={page === "history" ? { backgroundColor: "#1a1a1a" } : {}}
-            title="History"
-          >
-            <HistoryIcon size={13} />
-            History
-          </button>
         </div>
       </div>
 
@@ -133,10 +119,8 @@ export default function App() {
       <div className="flex-1 overflow-y-auto px-5 py-4">
         {page === "dashboard" ? (
           <Dashboard onNavigateToSettings={() => setPage("settings")} />
-        ) : page === "settings" ? (
-          <Settings onSaved={() => setPage("dashboard")} />
         ) : (
-          <History />
+          <Settings onSaved={() => setPage("dashboard")} />
         )}
       </div>
     </div>

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,0 +1,35 @@
+import { load } from "@tauri-apps/plugin-store";
+import type { ServiceData } from "@/types";
+
+export type HistorySnapshot = {
+  timestamp: string;   // "YYYY-MM-DD"
+  serviceId: string;   // "claude" | "chatgpt" | "cursor"
+  accountId: string;
+  data: ServiceData;
+};
+
+export async function loadHistory(): Promise<HistorySnapshot[]> {
+  const store = await load("history.json", { autoSave: false, defaults: {} });
+  return (await store.get<HistorySnapshot[]>("history")) ?? [];
+}
+
+export async function saveHistorySnapshot(
+  serviceId: string,
+  data: ServiceData
+): Promise<void> {
+  const store = await load("history.json", { autoSave: false, defaults: {} });
+  const history = (await store.get<HistorySnapshot[]>("history")) ?? [];
+  const today = new Date().toISOString().slice(0, 10); // "YYYY-MM-DD"
+
+  const exists = history.some(
+    (s) =>
+      s.timestamp === today &&
+      s.serviceId === serviceId &&
+      s.accountId === data.accountId
+  );
+  if (exists) return;
+
+  history.push({ timestamp: today, serviceId, accountId: data.accountId, data });
+  await store.set("history", history);
+  await store.save();
+}

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -19,7 +19,8 @@ export async function saveHistorySnapshot(
 ): Promise<void> {
   const store = await load("history.json", { autoSave: false, defaults: {} });
   const history = (await store.get<HistorySnapshot[]>("history")) ?? [];
-  const today = new Date().toISOString().slice(0, 10); // "YYYY-MM-DD"
+  const now = new Date();
+  const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
 
   const exists = history.some(
     (s) =>

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -10,6 +10,7 @@ import { ServiceDonutCard } from "@/components/dashboard/ServiceDonutCard";
 import { notify, getJwtExpiry } from "@/lib/notify";
 import { SERVICES } from "@/lib/services";
 import { saveHistorySnapshot } from "@/lib/history";
+import History from "@/pages/History";
 import type { Account, CredentialsStore } from "@/lib/credentials";
 import type { ServiceData } from "@/types";
 
@@ -233,6 +234,8 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
           </div>
         </>
       )}
+
+      <History />
     </div>
   );
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -9,6 +9,7 @@ import { NextResetCard } from "@/components/dashboard/NextResetCard";
 import { ServiceDonutCard } from "@/components/dashboard/ServiceDonutCard";
 import { notify, getJwtExpiry } from "@/lib/notify";
 import { SERVICES } from "@/lib/services";
+import { saveHistorySnapshot } from "@/lib/history";
 import type { Account, CredentialsStore } from "@/lib/credentials";
 import type { ServiceData } from "@/types";
 
@@ -153,6 +154,14 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
 
       setServices(results.filter((r): r is ServiceData => r !== null));
       setLastUpdated(new Date());
+
+      // Save one snapshot per account per day (silently, non-blocking)
+      for (let i = 0; i < settled.length; i++) {
+        const result = settled[i];
+        if (result.status === "fulfilled" && result.value.status === "ok") {
+          saveHistorySnapshot(toFetch[i].serviceId, result.value).catch(() => {});
+        }
+      }
     } catch (e) {
       console.error("Failed to fetch usage data", e);
       setFetchError(String(e));

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -149,7 +149,13 @@ function HistoryChart({
         <Tooltip
           // eslint-disable-next-line @typescript-eslint/no-explicit-any
           formatter={(value: any, name: any) => [`${value}%`, name]}
-          contentStyle={{ fontSize: 11, borderRadius: 8 }}
+          contentStyle={{
+            fontSize: 11,
+            borderRadius: 8,
+            backgroundColor: "var(--background)",
+            border: "1px solid var(--border)",
+            color: "var(--foreground)",
+          }}
         />
         {windowKeys.length > 1 && <Legend wrapperStyle={{ fontSize: 11, paddingTop: 4 }} />}
         {windowKeys.map((key, i) => (

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -16,18 +16,17 @@ import {
 
 type Range = "7d" | "30d" | "all";
 
-function cutoffDate(range: Range): Date | null {
+function cutoffDate(range: Range): string | null {
   if (range === "all") return null;
   const d = new Date();
   d.setDate(d.getDate() - (range === "7d" ? 7 : 30));
-  return d;
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
 }
 
 function filterByRange(snapshots: HistorySnapshot[], range: Range): HistorySnapshot[] {
   const cutoff = cutoffDate(range);
   if (!cutoff) return snapshots;
-  const cutoffStr = cutoff.toISOString().slice(0, 10);
-  return snapshots.filter((s) => s.timestamp >= cutoffStr);
+  return snapshots.filter((s) => s.timestamp >= cutoff);
 }
 
 // ── Time bucket ───────────────────────────────────────────────────────────────
@@ -179,9 +178,7 @@ export default function History() {
         )
       ).map((s) => s.id);
       setConfiguredServiceIds(configured);
-      if (configured.length > 0 && !selectedService) {
-        setSelectedService(configured[0]);
-      }
+      setSelectedService((prev) => (prev || configured[0] || ""));
     });
   }, []);
 

--- a/src/pages/History.tsx
+++ b/src/pages/History.tsx
@@ -1,0 +1,284 @@
+import { useState, useEffect } from "react";
+import { loadHistory, type HistorySnapshot } from "@/lib/history";
+import { SERVICES } from "@/lib/services";
+import { loadCredentials } from "@/lib/credentials";
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+
+// ── Time range ────────────────────────────────────────────────────────────────
+
+type Range = "7d" | "30d" | "all";
+
+function cutoffDate(range: Range): Date | null {
+  if (range === "all") return null;
+  const d = new Date();
+  d.setDate(d.getDate() - (range === "7d" ? 7 : 30));
+  return d;
+}
+
+function filterByRange(snapshots: HistorySnapshot[], range: Range): HistorySnapshot[] {
+  const cutoff = cutoffDate(range);
+  if (!cutoff) return snapshots;
+  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  return snapshots.filter((s) => s.timestamp >= cutoffStr);
+}
+
+// ── Time bucket ───────────────────────────────────────────────────────────────
+
+// Parse "YYYY-MM-DD" as local midnight to avoid UTC off-by-one in non-UTC timezones
+function parseLocalDate(dateStr: string): Date {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+function bucketKey(timestamp: string, range: Range): string {
+  if (range === "7d") return timestamp;
+  if (range === "30d") {
+    const d = parseLocalDate(timestamp);
+    const day = d.getDay();
+    const diff = day === 0 ? -6 : 1 - day;
+    d.setDate(d.getDate() + diff);
+    return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+  }
+  return timestamp.slice(0, 7);
+}
+
+function bucketLabel(key: string, range: Range): string {
+  if (range === "7d") {
+    return parseLocalDate(key).toLocaleDateString("en-US", { weekday: "short", month: "short", day: "numeric" });
+  }
+  if (range === "30d") {
+    return parseLocalDate(key).toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  }
+  const [year, month] = key.split("-");
+  return new Date(Number(year), Number(month) - 1).toLocaleDateString("en-US", { month: "short", year: "numeric" });
+}
+
+// ── Chart data ────────────────────────────────────────────────────────────────
+
+type ChartRow = { bucket: string; [windowLabel: string]: number | string };
+
+function allBucketKeys(range: Range): string[] {
+  if (range === "all") return [];
+  const days = range === "7d" ? 7 : 30;
+  const keys = new Set<string>();
+  for (let i = 0; i < days; i++) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    const ts = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+    keys.add(bucketKey(ts, range));
+  }
+  return Array.from(keys).sort();
+}
+
+function buildChartData(
+  snapshots: HistorySnapshot[],
+  range: Range,
+  knownWindowLabels: string[]
+): ChartRow[] {
+  const byBucket = new Map<string, HistorySnapshot>();
+  for (const s of snapshots) {
+    const key = bucketKey(s.timestamp, range);
+    const existing = byBucket.get(key);
+    if (!existing || s.timestamp > existing.timestamp) {
+      byBucket.set(key, s);
+    }
+  }
+
+  const placeholderKeys = allBucketKeys(range).filter((k) => !byBucket.has(k));
+  const allKeys = [...Array.from(byBucket.keys()), ...placeholderKeys].sort((a, b) =>
+    a.localeCompare(b)
+  );
+
+  return allKeys.map((key) => {
+    const snap = byBucket.get(key);
+    const row: ChartRow = { bucket: bucketLabel(key, range) };
+    for (const label of knownWindowLabels) {
+      row[label] = snap ? (snap.data.windows.find((w) => w.label === label)?.usedPercent ?? 0) : 0;
+    }
+    return row;
+  });
+}
+
+function windowLabels(snapshots: HistorySnapshot[]): string[] {
+  const labels = new Set<string>();
+  for (const s of snapshots) {
+    for (const w of s.data.windows) labels.add(w.label);
+  }
+  return Array.from(labels);
+}
+
+// ── Chart component ───────────────────────────────────────────────────────────
+
+function lighten(hex: string, amount = 0.35): string {
+  const num = parseInt(hex.replace("#", ""), 16);
+  const r = Math.min(255, Math.round(((num >> 16) & 0xff) + 255 * amount));
+  const g = Math.min(255, Math.round(((num >> 8) & 0xff) + 255 * amount));
+  const b = Math.min(255, Math.round((num & 0xff) + 255 * amount));
+  return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
+}
+
+function HistoryChart({
+  data,
+  windowKeys,
+  color,
+}: {
+  data: ChartRow[];
+  windowKeys: string[];
+  color: string;
+}) {
+  const colors = [color, lighten(color)];
+
+  return (
+    <ResponsiveContainer width="100%" height={180}>
+      <BarChart data={data} margin={{ top: 4, right: 4, left: -20, bottom: 0 }}>
+        <XAxis dataKey="bucket" tick={{ fontSize: 10 }} tickLine={false} axisLine={false} />
+        <YAxis
+          domain={[0, 100]}
+          tickFormatter={(v) => `${v}%`}
+          tick={{ fontSize: 10 }}
+          tickLine={false}
+          axisLine={false}
+        />
+        <Tooltip
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          formatter={(value: any, name: any) => [`${value}%`, name]}
+          contentStyle={{ fontSize: 11, borderRadius: 8 }}
+        />
+        {windowKeys.length > 1 && <Legend wrapperStyle={{ fontSize: 11, paddingTop: 4 }} />}
+        {windowKeys.map((key, i) => (
+          <Bar key={key} dataKey={key} fill={colors[i % colors.length]} radius={[3, 3, 0, 0]} maxBarSize={28} />
+        ))}
+      </BarChart>
+    </ResponsiveContainer>
+  );
+}
+
+// ── Page component ────────────────────────────────────────────────────────────
+
+export default function History() {
+  const [allSnapshots, setAllSnapshots] = useState<HistorySnapshot[]>([]);
+  const [configuredServiceIds, setConfiguredServiceIds] = useState<string[]>([]);
+  const [selectedService, setSelectedService] = useState<string>("");
+  const [selectedAccountId, setSelectedAccountId] = useState<string>("");
+  const [range, setRange] = useState<Range>("7d");
+
+  useEffect(() => {
+    Promise.all([loadHistory(), loadCredentials()]).then(([history, creds]) => {
+      setAllSnapshots(history);
+      const configured = SERVICES.filter((s) =>
+        (creds[s.id] ?? []).some((a) =>
+          Object.values(a.credentials).some((v) => v.trim())
+        )
+      ).map((s) => s.id);
+      setConfiguredServiceIds(configured);
+      if (configured.length > 0 && !selectedService) {
+        setSelectedService(configured[0]);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!selectedService) return;
+    const ids = [
+      ...new Set(
+        allSnapshots.filter((s) => s.serviceId === selectedService).map((s) => s.accountId)
+      ),
+    ];
+    setSelectedAccountId(ids[0] ?? "");
+  }, [selectedService, allSnapshots]);
+
+  const serviceSnapshots = allSnapshots.filter(
+    (s) => s.serviceId === selectedService && s.accountId === selectedAccountId
+  );
+  const rangeFiltered = filterByRange(serviceSnapshots, range);
+  const windowKeys = windowLabels(rangeFiltered);
+  const chartData = buildChartData(rangeFiltered, range, windowKeys);
+
+  const accountIds = [
+    ...new Set(
+      allSnapshots.filter((s) => s.serviceId === selectedService).map((s) => s.accountId)
+    ),
+  ];
+  const showAccountTabs = accountIds.length > 1;
+  const serviceColor = SERVICES.find((s) => s.id === selectedService)?.color ?? "#888";
+
+  return (
+    <div className="space-y-3">
+      {/* Service tabs */}
+      <div className="flex gap-1 flex-wrap">
+        {configuredServiceIds.map((id) => {
+          const svc = SERVICES.find((s) => s.id === id)!;
+          const color = SERVICES.find((s) => s.id === id)?.color ?? "#888";
+          return (
+            <button
+              key={id}
+              onClick={() => setSelectedService(id)}
+              className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+                selectedService === id ? "text-white" : "text-muted-foreground hover:text-foreground"
+              }`}
+              style={selectedService === id ? { backgroundColor: color } : {}}
+            >
+              {svc.name}
+            </button>
+          );
+        })}
+      </div>
+
+      {/* Account tabs */}
+      {showAccountTabs && (
+        <div className="flex gap-1 flex-wrap">
+          {accountIds.map((id) => {
+            const label =
+              allSnapshots.find((s) => s.serviceId === selectedService && s.accountId === id)?.data
+                .label ?? id.slice(0, 8);
+            return (
+              <button
+                key={id}
+                onClick={() => setSelectedAccountId(id)}
+                className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+                  selectedAccountId === id
+                    ? "bg-secondary text-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                }`}
+              >
+                {label}
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Time range */}
+      <div className="flex gap-1">
+        {(["7d", "30d", "all"] as Range[]).map((r) => (
+          <button
+            key={r}
+            onClick={() => setRange(r)}
+            className={`px-3 py-1.5 rounded-full text-xs font-medium transition-colors ${
+              range === r ? "bg-secondary text-foreground" : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {r === "all" ? "All" : r}
+          </button>
+        ))}
+      </div>
+
+      {/* Chart or empty state */}
+      {chartData.length === 0 || windowKeys.length === 0 ? (
+        <p className="text-center text-sm text-muted-foreground py-12">
+          No history yet. Usage is recorded once per day.
+        </p>
+      ) : (
+        <HistoryChart data={chartData} windowKeys={windowKeys} color={serviceColor} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds usage history to uso.ai — records one snapshot per account per day and renders a grouped bar chart at the bottom of the Dashboard.

## Features

- **Daily snapshots** — saved automatically after each successful fetch; one per `(date, serviceId, accountId)`; deduped so refreshing multiple times a day doesn't create duplicates
- **Bar chart** — embedded at the bottom of Dashboard; grouped bars per time bucket, one bar per usage window (e.g. Current session, Weekly), service brand color
- **Service tabs** — only configured services shown
- **Account tabs** — shown only when a service has >1 account with history
- **Time ranges** — 7d (daily bars), 30d (weekly bars), All (monthly bars)
- **Placeholder bars** — empty days/weeks show 0% bars so the x-axis stays consistent
- **Dark mode tooltip** — chart tooltip uses CSS variables to match light/dark/system theme
- **Empty state** — "No history yet. Usage is recorded once per day."

## Technical notes

- Storage: `history.json` via existing `tauri-plugin-store` — no new dependencies
- `recharts` was already installed at ^3.8.0
- Dates use local timezone throughout (not UTC) to avoid off-by-one on non-UTC systems
- Timezone-safe `parseLocalDate` helper used for all "YYYY-MM-DD" → Date conversions

🤖 Generated with [Claude Code](https://claude.com/claude-code)