### PR TITLE
fix: improve Settings tab layout with 2x2 grid

### DIFF
--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -205,18 +205,20 @@ export default function Settings({ onSaved }: Props) {
       </div>
 
       <Tabs defaultValue="claude">
-        <TabsList className="w-full">
+        <TabsList className="w-full grid grid-cols-2 !h-auto !p-1 gap-1">
           {SERVICES.map((service) => {
             const configured = service.id === "gemini"
               ? geminiDetected
               : isServiceConfigured(persisted[service.id] ?? [], service.fields);
             return (
-              <TabsTrigger key={service.id} value={service.id} className="flex-1 gap-2">
+              <TabsTrigger key={service.id} value={service.id} className="!h-9 gap-2 justify-start px-3">
                 <ServiceAvatar name={service.name} size="sm" />
-                {service.name}
+                <span className="truncate text-xs">
+                  {service.id === "chatgpt" ? "ChatGPT" : service.name}
+                </span>
                 {configured
-                  ? <CheckCircle2 size={12} className="text-muted-foreground ml-auto" />
-                  : <Circle size={12} className="text-muted-foreground/40 ml-auto" />
+                  ? <CheckCircle2 size={12} className="text-muted-foreground ml-auto shrink-0" />
+                  : <Circle size={12} className="text-muted-foreground/40 ml-auto shrink-0" />
                 }
               </TabsTrigger>
             );


### PR DESCRIPTION
## Summary
- Replaced single-row tab list with a 2×2 grid layout to prevent overflow
- Shortened "ChatGPT (Codex)" to "ChatGPT" in the tab trigger to save space
- Added `truncate` and `shrink-0` to prevent text/icon overflow within cells
- Overrode base-ui's conflicting `h-8` and `inline-flex` defaults with `!h-auto` and `!h-9`

## Test plan
- [ ] All 4 service tabs (Claude, ChatGPT, Cursor, Gemini CLI) are visible and clickable
- [ ] Active tab highlights correctly
- [ ] Configured/unconfigured status icons display properly
- [ ] Tab content loads correctly for each service

🤖 Generated with [Claude Code](https://claude.com/claude-code)