### PR TITLE
fix: detect Claude plan from account data

### DIFF
--- a/src/components/dashboard/ServiceDonutCard.tsx
+++ b/src/components/dashboard/ServiceDonutCard.tsx
@@ -20,7 +20,11 @@ export function ServiceDonutCard({ service, onSettings }: Props) {
 
   return (
     <Card className="relative">
-      <Badge variant="outline" className="absolute top-3 right-3 text-xs font-normal">{service.plan}</Badge>
+      {service.plan && (
+        <Badge variant="outline" className="absolute top-3 right-3 text-xs font-normal">
+          {service.plan}
+        </Badge>
+      )}
       <CardHeader className="px-4 pt-3 pb-2 flex-row items-center space-y-0">
         <div className="flex items-center gap-2">
           <ServiceAvatar name={service.name} />

--- a/src/lib/api/claude.ts
+++ b/src/lib/api/claude.ts
@@ -7,17 +7,101 @@ type ClaudeUsageResponse = {
   seven_day: { utilization: number; resets_at: string | null } | null;
 };
 
-async function fetchClaudeEmail(sessionKey: string): Promise<string | undefined> {
+type ClaudeAccountResponse = Record<string, unknown>;
+
+type ClaudeAccountInfo = {
+  email?: string;
+  plan: string;
+};
+
+const DEFAULT_CLAUDE_PLAN = "Pro";
+
+function titleCase(value: string): string {
+  return value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function normalizeClaudePlan(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+
+  const normalized = value.trim().toLowerCase().replace(/[_-]+/g, " ");
+  if (!normalized) return undefined;
+
+  if (normalized.includes("max")) return "Max";
+  if (normalized.includes("pro")) return "Pro";
+  if (normalized.includes("team")) return "Team";
+  if (normalized.includes("enterprise")) return "Enterprise";
+  if (normalized.includes("free")) return "Free";
+
+  return titleCase(normalized);
+}
+
+function findPlanCandidate(
+  value: unknown,
+  keyHint = "",
+  depth = 0
+): string | undefined {
+  if (depth > 3 || value == null) return undefined;
+
+  if (typeof value === "string") {
+    return /(plan|tier|subscription|membership)/i.test(keyHint)
+      ? normalizeClaudePlan(value)
+      : undefined;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const plan = findPlanCandidate(item, keyHint, depth + 1);
+      if (plan) return plan;
+    }
+    return undefined;
+  }
+
+  if (typeof value !== "object") return undefined;
+
+  const record = value as Record<string, unknown>;
+  const prioritizedKeys = [
+    "subscription_tier",
+    "subscriptionTier",
+    "plan",
+    "plan_type",
+    "planType",
+    "tier",
+    "membership_type",
+    "membershipType",
+  ];
+
+  for (const key of prioritizedKeys) {
+    const plan = findPlanCandidate(record[key], key, depth + 1);
+    if (plan) return plan;
+  }
+
+  for (const [key, nestedValue] of Object.entries(record)) {
+    const plan = findPlanCandidate(nestedValue, key, depth + 1);
+    if (plan) return plan;
+  }
+
+  return undefined;
+}
+
+async function fetchClaudeAccountInfo(sessionKey: string): Promise<ClaudeAccountInfo> {
   try {
     const res = await fetch("https://claude.ai/api/me", {
       method: "GET",
       headers: { Cookie: `sessionKey=${sessionKey}` },
     });
-    if (!res.ok) return undefined;
-    const data = (await res.json()) as { email?: string };
-    return data.email ?? undefined;
+    if (!res.ok) return { plan: DEFAULT_CLAUDE_PLAN };
+
+    const data = (await res.json()) as ClaudeAccountResponse;
+    const email = typeof data.email === "string" ? data.email : undefined;
+    const plan = findPlanCandidate(data) ?? DEFAULT_CLAUDE_PLAN;
+
+    return { email, plan };
   } catch {
-    return undefined;
+    return { plan: DEFAULT_CLAUDE_PLAN };
   }
 }
 
@@ -25,6 +109,7 @@ export async function fetchClaudeUsage(
   orgId: string,
   sessionKey: string
 ): Promise<ServiceData> {
+  const accountPromise = fetchClaudeAccountInfo(sessionKey);
   const res = await fetch(
     `https://claude.ai/api/organizations/${orgId}/usage`,
     {
@@ -36,14 +121,30 @@ export async function fetchClaudeUsage(
   );
 
   if (res.status === 401 || res.status === 403) {
-    return { name: "Claude", plan: "Pro", status: "expired", windows: [], accountId: "" };
+    const account = await accountPromise;
+    return {
+      name: "Claude",
+      plan: account.plan,
+      status: "expired",
+      windows: [],
+      email: account.email,
+      accountId: "",
+    };
   }
   if (!res.ok) {
-    return { name: "Claude", plan: "Pro", status: "error", windows: [], accountId: "" };
+    const account = await accountPromise;
+    return {
+      name: "Claude",
+      plan: account.plan,
+      status: "error",
+      windows: [],
+      email: account.email,
+      accountId: "",
+    };
   }
 
   const data = (await res.json()) as ClaudeUsageResponse;
-const windows = [];
+  const windows = [];
 
   if (data.five_hour) {
     windows.push({
@@ -60,6 +161,13 @@ const windows = [];
     });
   }
 
-  const email = await fetchClaudeEmail(sessionKey);
-  return { name: "Claude", plan: "Pro", status: "ok", windows, email, accountId: "" };
+  const account = await accountPromise;
+  return {
+    name: "Claude",
+    plan: account.plan,
+    status: "ok",
+    windows,
+    email: account.email,
+    accountId: "",
+  };
 }

--- a/src/lib/api/claude.ts
+++ b/src/lib/api/claude.ts
@@ -14,7 +14,7 @@ type ClaudeAccountInfo = {
   plan: string;
 };
 
-const DEFAULT_CLAUDE_PLAN = "Pro";
+const DEFAULT_CLAUDE_PLAN = "";
 
 function titleCase(value: string): string {
   return value


### PR DESCRIPTION
## Summary
- replace Claude's email-only `api/me` lookup with shared account metadata parsing
- derive the displayed Claude plan from account response fields instead of hardcoding `Pro`
- reuse the detected plan on success, expired, and error states so the badge stays accurate

## Why
Claude accounts upgraded to Max still showed a `Pro` badge because `src/lib/api/claude.ts` returned `plan: "Pro"` on every code path, regardless of the actual account tier.

## Implementation notes
- added defensive plan normalization for likely Claude account fields such as plan, tier, membership, and subscription variants
- kept a fallback to `Pro` when Claude's internal account payload does not expose a recognizable plan value
- preserved existing usage window behavior and email display

## Validation
- `npm run build`

Closes #17
