### PR TITLE
fix(gemini): unblock dashboard — perms, schema, labels, past-reset display

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -15,7 +15,7 @@
     "global-shortcut:allow-unregister",
     "global-shortcut:allow-is-registered",
     {
-      "identifier": "fs:allow-read-file",
+      "identifier": "fs:allow-read-text-file",
       "allow": [{ "path": "$HOME/.gemini/**" }]
     },
     {

--- a/src/lib/api/gemini.ts
+++ b/src/lib/api/gemini.ts
@@ -56,6 +56,15 @@ function tierToPlan(tier: string): string {
   return "";
 }
 
+// "gemini-2.5-flash-lite" → "2.5 Flash Lite", "gemini-3-flash-preview" → "3 Flash Preview"
+function formatGeminiModelLabel(modelId: string): string {
+  return modelId
+    .replace(/^gemini-/, "")
+    .split("-")
+    .map((part) => (part.length > 0 ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(" ");
+}
+
 function notConfigured(): ServiceData {
   return { accountId: "gemini", name: "Gemini CLI", plan: "", status: "not_configured", windows: [] };
 }
@@ -173,6 +182,7 @@ export async function fetchGeminiUsage(): Promise<ServiceData> {
   if (!projectId) return errorResult(tierToPlan(tier));
 
   // Step 2: retrieveUserQuota — get per-model usage
+  // Google's response uses `buckets` (was `quotaBuckets` in earlier API versions)
   let buckets: QuotaBucket[] = [];
   try {
     const res = await fetch("https://cloudcode-pa.googleapis.com/v1internal:retrieveUserQuota", {
@@ -184,13 +194,13 @@ export async function fetchGeminiUsage(): Promise<ServiceData> {
       body: JSON.stringify({ project: projectId }),
     });
     if (!res.ok) return errorResult(tierToPlan(tier));
-    const data = (await res.json()) as { quotaBuckets?: QuotaBucket[] };
-    buckets = data.quotaBuckets ?? [];
+    const data = (await res.json()) as { buckets?: QuotaBucket[]; quotaBuckets?: QuotaBucket[] };
+    buckets = data.buckets ?? data.quotaBuckets ?? [];
   } catch {
     return errorResult(tierToPlan(tier));
   }
 
-  // Map buckets to UsageWindows (Pro + Flash only)
+  // Map buckets to UsageWindows (Pro + Flash variants only)
   const windows = buckets
     .filter((b) => {
       const id = b.modelId ?? b.model_id ?? "";
@@ -198,11 +208,10 @@ export async function fetchGeminiUsage(): Promise<ServiceData> {
     })
     .map((b) => {
       const id = b.modelId ?? b.model_id ?? "";
-      const label = id.includes("pro") ? "Pro" : "Flash";
       const remaining = b.remainingFraction ?? b.remaining_fraction ?? 0;
       const resetIso = b.resetTime ?? b.reset_time ?? null;
       return {
-        label,
+        label: formatGeminiModelLabel(id),
         usedPercent: Math.round((1 - remaining) * 100),
         resetsAt: formatResetTime(resetIso),
       };

--- a/src/lib/api/utils.ts
+++ b/src/lib/api/utils.ts
@@ -9,6 +9,10 @@ export function formatResetTime(isoString: string | null): string {
   const diffMs = date.getTime() - Date.now();
   const diffMins = Math.round(diffMs / 60000);
 
+  // Past timestamps (e.g. Google's "1970-01-01" sentinel for exhausted-no-reset
+  // buckets, or any reset that already fired between fetch cycles) → show "—".
+  if (diffMins <= 0) return "—";
+
   if (diffMins < 60) return `in ${diffMins}m`;
   if (diffMins < 360) {
     const h = Math.floor(diffMins / 60);


### PR DESCRIPTION
## Summary
Three independent bugs that all surfaced when running the Gemini CLI integration end-to-end on a fresh checkout. None were visible until the integration actually ran against a real `~/.gemini/oauth_creds.json` and a real Google quota response.

- **`capabilities/default.json`** — switch from `fs:allow-read-file` (binary read) to `fs:allow-read-text-file` so `readTextFile()` of `~/.gemini/oauth_creds.json` is actually permitted. The denial was being caught and surfaced as a misleading **"Token expired"** in the UI even though the on-disk token was fine.
- **`gemini.ts`** — read `buckets` (with `quotaBuckets` as a fallback) from the `retrieveUserQuota` response. Google renamed the field at some point and the old name now returns `undefined` → empty bucket array → `windows.length === 0` → **"Fetch failed"**. Also use a per-variant model label (e.g. `2.5 Flash Lite`, `3 Flash Preview`) instead of collapsing every variant into `Pro`/`Flash`, which made the dashboard cards visually indistinguishable now that the response includes multiple flash variants.
- **`utils.ts` (`formatResetTime`)** — return `"—"` for any timestamp in the past so Google's `1970-01-01` sentinel for exhausted-no-reset buckets stops rendering as **`in -29599075m`**. Also defends every other service against a reset that fires between fetch cycles.

## Test plan
- [ ] Fresh checkout, `npm install && npm run tauri dev`
- [ ] With a valid `~/.gemini/oauth_creds.json` (any tier), open the menu bar dashboard — Gemini CLI card should populate, no "Token expired" / "Fetch failed"
- [ ] Verify per-model labels show variant names (e.g. "2.5 Flash", "2.5 Flash Lite", "3 Flash Preview", "2.5 Pro") rather than just "Flash"/"Pro"
- [ ] If your Pro quota is exhausted, verify the reset column shows `—` (not a negative-minutes string)
- [ ] Spot-check Claude / ChatGPT / Cursor cards still render normally (the `formatResetTime` change is shared)

🤖 Generated with [Claude Code](https://claude.com/claude-code)