### PR TITLE
feat(dashboard): live service status + richer Claude usage (TOK-37)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,14 +13,15 @@ macOS menu bar app that provides a usage dashboard for AI subscription services 
 ## Project Structure
 ```
 src/
-  pages/          — Dashboard, Settings
+  pages/          — Dashboard, Settings, History
   components/
-    dashboard/    — ServiceDonutCard, NextResetCard
+    dashboard/    — ServiceDonutCard, NextResetCard, SubscriptionPanel, DonutChart
     ui/           — shadcn primitives (Button, Card, Badge, etc.)
   lib/
-    api/          — claude.ts, chatgpt.ts, cursor.ts (fetch usage + email)
-    credentials.ts — load/save credentials via tauri-plugin-store
+    api/          — claude.ts, chatgpt.ts, cursor.ts, gemini.ts, utils.ts (fetch usage + email)
+    credentials.ts — load/save credentials via tauri-plugin-store (multi-account per service)
     services.ts   — service metadata (name, color, logo, credential fields)
+    history.ts    — daily usage snapshots for the History view
     useTheme.ts   — light/dark/system theme toggle
     notify.ts     — desktop notifications + JWT expiry helpers
   types.ts        — ServiceData, UsageWindow, ServiceStatus
@@ -48,6 +49,9 @@ npm run tauri build     # Build production .app bundle
 | Claude | `GET https://claude.ai/api/organizations/{org_id}/usage` | Cookie: `sessionKey` | `GET https://claude.ai/api/me` (TBC) |
 | ChatGPT (Codex) | `GET https://chatgpt.com/backend-api/wham/usage` | Header: `Authorization: Bearer {token}` | `GET https://chatgpt.com/backend-api/me` |
 | Cursor | `GET https://cursor.com/api/usage-summary` | Cookie: `WorkosCursorSessionToken` | `GET https://cursor.com/api/auth/me` |
+| Gemini CLI | `POST https://cloudcode-pa.googleapis.com/...` (Code Assist API) | OAuth access token refreshed via `https://oauth2.googleapis.com` | Read from `~/.gemini/oauth_creds.json` |
+
+**Gemini is file-based, not credential-store-based.** It reads `~/.gemini/oauth_creds.json` (tokens) and `~/.gemini/settings.json` directly via `tauri-plugin-fs` (scoped to `$HOME/.gemini/**` in capabilities). No Settings UI entry. OAuth tokens are auto-refreshed and cached in-memory between fetch cycles.
 
 ## Architecture Notes
 - **Menu bar app** — no Dock icon (`ActivationPolicy::Accessory` + `LSUIElement`), window hidden by default, toggled via tray click or `Cmd+Shift+U`
@@ -56,7 +60,10 @@ npm run tauri build     # Build production .app bundle
 - **Fade in/out** — CSS `popup-in` / `popup-out` animations triggered via Tauri `onFocusChanged` and window blur events
 - **Tray icon** — monochrome 18×18 RGBA template image (`icon_as_template(true)`), auto-inverts for light/dark menu bar
 - **Credentials** — stored locally via `tauri-plugin-store` (`credentials.json`), never synced to cloud
+- **Multi-account** — `CredentialsStore` is shaped `{ [serviceId]: Account[] }`; each account has `{ id, label, credentials }`. When a service has >1 configured account, the label is shown on its card (e.g. "Claude · Work").
 - **Account email** — fetched from each service's user-info endpoint and displayed in the service card
+- **History** — one usage snapshot per account per day is persisted via `saveHistorySnapshot` and shown on the History page. Snapshots only save when `status === "ok"`.
+- **Token-expiry notifications** — ChatGPT Bearer tokens are JWTs; `Dashboard` runs a 1-min background interval that fires a desktop notification at 30-min and 3-min thresholds (deduped per token).
 - **No official APIs** — all endpoints are internal web APIs; may break on service updates
 
 ## Key Features (current)
@@ -79,3 +86,58 @@ npm run tauri build     # Build production .app bundle
 | `tauri-plugin-global-shortcut` | `Cmd+Shift+U` toggle shortcut |
 | `tauri-plugin-positioner` | Position window below tray icon |
 | `tauri-plugin-opener` | Open external links |
+
+## Branching — git flow
+
+This project follows **git flow**. Always keep this in mind:
+
+- `master` is the production branch. Never commit or branch directly off it for new work.
+- `develop` is the integration branch. **All feature branches are cut off `develop`, and all feature PRs target `develop`.**
+- Feature branches: `feature/<name>` off `develop` → PR back into `develop`.
+- Release branches: `release/<version>` off `develop` → merged into both `master` and `develop`.
+- Hotfix branches: `hotfix/<name>` off `master` → merged into both `master` and `develop`.
+
+When any skill (office-hours, plan-eng-review, ship, etc.) refers to "the base branch" or "cut from master", interpret it as `develop` for feature work. Only release and hotfix flows touch `master` directly.
+
+## Linear ticket workflow
+
+When working on a Linear ticket for this repo, always follow this routine:
+
+1. **Review** — read the ticket details and understand the scope.
+2. **Move to In Progress** — update the ticket status if it's not already there.
+3. **Create branch** — cut a `feature/<name>` or `bugfix/<name>` branch off `develop`.
+4. **Implement & create PR** — do the work, commit, and open a PR targeting `develop`.
+5. **Update ticket** — once the PR is created, update the Linear ticket status (e.g., In Review) and link the PR.
+
+## gstack (recommended)
+
+This project uses [gstack](https://github.com/garrytan/gstack) for AI-assisted workflows.
+Install it for the best experience:
+
+```bash
+git clone --depth 1 https://github.com/garrytan/gstack.git ~/.claude/skills/gstack
+cd ~/.claude/skills/gstack && ./setup --team
+```
+
+Skills like /qa, /ship, /review, /investigate, and /browse become available after install.
+Use /browse for all web browsing. Use ~/.claude/skills/gstack/... for gstack file paths.
+
+## Skill routing
+
+When the user's request matches an available skill, ALWAYS invoke it using the Skill
+tool as your FIRST action. Do NOT answer directly, do NOT use other tools first.
+The skill has specialized workflows that produce better results than ad-hoc answers.
+
+Key routing rules:
+- Product ideas, "is this worth building", brainstorming → invoke office-hours
+- Bugs, errors, "why is this broken" → invoke investigate
+- Ship, deploy, push, create PR → invoke ship
+- QA, test the app, find bugs → invoke qa
+- Code review, check my diff → invoke review
+- Update docs after shipping → invoke document-release
+- Weekly retro → invoke retro
+- Design system, brand → invoke design-consultation
+- Visual audit, design polish → invoke design-review
+- Architecture review → invoke plan-eng-review
+- Save progress, checkpoint, resume → invoke checkpoint
+- Code quality, health check → invoke health

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -30,7 +30,10 @@
         { "url": "https://cursor.com/**" },
         { "url": "https://www.cursor.com/**" },
         { "url": "https://cloudcode-pa.googleapis.com/**" },
-        { "url": "https://oauth2.googleapis.com/**" }
+        { "url": "https://oauth2.googleapis.com/**" },
+        { "url": "https://status.anthropic.com/**" },
+        { "url": "https://status.openai.com/**" },
+        { "url": "https://status.cursor.com/**" }
       ]
     }
   ]

--- a/src/components/dashboard/ServiceDonutCard.tsx
+++ b/src/components/dashboard/ServiceDonutCard.tsx
@@ -3,7 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { ServiceAvatar } from "@/components/ServiceAvatar";
 import { getServiceByName } from "@/lib/services";
-import type { ServiceData } from "@/types";
+import type { OperationalStatus, ServiceData } from "@/types";
 
 type Props = { service: ServiceData; onSettings?: () => void };
 
@@ -13,6 +13,29 @@ function usageBarColor(percent: number, fallback: string): string {
   return fallback;
 }
 
+// Hoisted module-level to avoid re-creating per render.
+const OPERATIONAL_META: Record<
+  Exclude<OperationalStatus, "unknown">,
+  { color: string; label: string }
+> = {
+  operational: { color: "#22c55e", label: "Operational" },
+  degraded: { color: "#eab308", label: "Degraded performance" },
+  outage: { color: "#ef4444", label: "Outage" },
+};
+
+function StatusDot({ status }: { status: OperationalStatus }) {
+  if (status === "unknown") return null;
+  const { color, label } = OPERATIONAL_META[status];
+  return (
+    <span
+      title={label}
+      aria-label={`Service status: ${label}`}
+      className="inline-block size-2 rounded-full shrink-0"
+      style={{ backgroundColor: color }}
+    />
+  );
+}
+
 export function ServiceDonutCard({ service, onSettings }: Props) {
   const color = getServiceByName(service.name)?.color ?? "#888";
   const isExpired = service.status === "expired";
@@ -20,7 +43,10 @@ export function ServiceDonutCard({ service, onSettings }: Props) {
 
   return (
     <Card className="relative">
-      <Badge variant="outline" className="absolute top-3 right-3 text-xs font-normal">{service.plan}</Badge>
+      <div className="absolute top-3 right-3 flex items-center gap-1.5">
+        {service.operational && <StatusDot status={service.operational} />}
+        <Badge variant="outline" className="text-xs font-normal">{service.plan}</Badge>
+      </div>
       <CardHeader className="px-4 pt-3 pb-2 flex-row items-center space-y-0">
         <div className="flex items-center gap-2">
           <ServiceAvatar name={service.name} />
@@ -67,6 +93,37 @@ export function ServiceDonutCard({ service, onSettings }: Props) {
                 </div>
               </div>
             ))}
+            {service.extraUsage && (() => {
+              const { usedDollars, monthlyLimitDollars } = service.extraUsage;
+              const pct =
+                monthlyLimitDollars > 0
+                  ? Math.round((usedDollars / monthlyLimitDollars) * 100)
+                  : 0;
+              return (
+                <div className="space-y-1">
+                  <div className="flex items-center justify-between">
+                    <span className="text-xs text-muted-foreground">Extra usage</span>
+                    <div className="flex items-center gap-1.5 text-xs">
+                      <span className="font-medium text-foreground">
+                        ${usedDollars.toFixed(2)}
+                      </span>
+                      <span className="text-muted-foreground/50">
+                        · of ${monthlyLimitDollars.toFixed(2)}
+                      </span>
+                    </div>
+                  </div>
+                  <div className="h-1.5 w-full rounded-full overflow-hidden bg-muted">
+                    <div
+                      className="h-full rounded-full transition-all"
+                      style={{
+                        width: `${Math.min(pct, 100)}%`,
+                        backgroundColor: usageBarColor(pct, color),
+                      }}
+                    />
+                  </div>
+                </div>
+              );
+            })()}
           </div>
         )}
       </CardContent>

--- a/src/components/dashboard/ServiceStatusPanel.tsx
+++ b/src/components/dashboard/ServiceStatusPanel.tsx
@@ -1,0 +1,76 @@
+import { ExternalLink } from "lucide-react";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { Card, CardContent } from "@/components/ui/card";
+import { ServiceAvatar } from "@/components/ServiceAvatar";
+import { SERVICES } from "@/lib/services";
+import type { OperationalStatus, ServiceStatusInfo } from "@/types";
+
+// Hoisted module-level so the row renderer doesn't rebuild it each render.
+const STATUS_META: Record<OperationalStatus, { color: string; label: string }> = {
+  operational: { color: "#22c55e", label: "All systems operational" },
+  degraded: { color: "#eab308", label: "Degraded performance" },
+  outage: { color: "#ef4444", label: "Service outage" },
+  unknown: { color: "#9ca3af", label: "Status unavailable" },
+};
+
+type Props = {
+  /** Service ids the user has integrated (Claude/ChatGPT/Cursor/Gemini). */
+  integratedServiceIds: string[];
+  /** Status info keyed by service id — from fetchAllOperationalStatuses. */
+  statusByService: Record<string, ServiceStatusInfo>;
+};
+
+export function ServiceStatusPanel({ integratedServiceIds, statusByService }: Props) {
+  // Only render a row per service that (a) the user has integrated AND (b) we
+  // have a status page for. Deduped so multi-account users see one row each.
+  const rows = Array.from(new Set(integratedServiceIds))
+    .map((id) => {
+      const service = SERVICES.find((s) => s.id === id);
+      const info = statusByService[id];
+      if (!service || !info) return null;
+      return { id, service, info };
+    })
+    .filter((r): r is NonNullable<typeof r> => r !== null);
+
+  if (rows.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <h2 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider px-1">
+        Service status
+      </h2>
+      <Card>
+        <CardContent className="p-0 divide-y divide-border/50">
+          {rows.map(({ id, service, info }) => {
+            const meta = STATUS_META[info.status];
+            return (
+              <button
+                key={id}
+                onClick={() => openUrl(info.page).catch(() => {})}
+                aria-label={`Open ${service.name} status page`}
+                className="w-full flex items-center gap-2.5 px-3 py-2 hover:bg-muted/40 transition-colors text-left group"
+              >
+                <ServiceAvatar name={service.name} size="sm" />
+                <div className="flex-1 min-w-0 flex items-center gap-2">
+                  <span className="text-sm font-medium shrink-0">{service.name}</span>
+                  <span
+                    className="inline-block size-1.5 rounded-full shrink-0"
+                    style={{ backgroundColor: meta.color }}
+                    aria-hidden="true"
+                  />
+                  <span className="text-xs text-muted-foreground truncate">
+                    {info.description ?? meta.label}
+                  </span>
+                </div>
+                <ExternalLink
+                  size={12}
+                  className="text-muted-foreground/0 group-hover:text-muted-foreground transition-colors shrink-0"
+                />
+              </button>
+            );
+          })}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/lib/api/claude.ts
+++ b/src/lib/api/claude.ts
@@ -2,9 +2,25 @@ import { fetch } from "@tauri-apps/plugin-http";
 import { formatResetTime } from "@/lib/api/utils";
 import type { ServiceData } from "@/types";
 
+type UsageBucket = { utilization: number; resets_at: string | null } | null;
+
 type ClaudeUsageResponse = {
-  five_hour: { utilization: number; resets_at: string | null } | null;
-  seven_day: { utilization: number; resets_at: string | null } | null;
+  five_hour: UsageBucket;
+  seven_day: UsageBucket;
+  /** "Weekly · Sonnet only" bucket — only populated on plans with a Sonnet-specific limit. */
+  seven_day_sonnet?: UsageBucket;
+  /** "Weekly · Opus only" bucket — only populated on plans with an Opus-specific limit. */
+  seven_day_opus?: UsageBucket;
+  /**
+   * Pay-as-you-go spend. `monthly_limit` is returned in **cents**,
+   * `used_credits` is returned in **dollars** (float).
+   */
+  extra_usage?: {
+    is_enabled: boolean;
+    monthly_limit: number;
+    used_credits: number;
+    utilization: number | null;
+  };
 };
 
 async function fetchClaudeEmail(sessionKey: string): Promise<string | undefined> {
@@ -43,7 +59,7 @@ export async function fetchClaudeUsage(
   }
 
   const data = (await res.json()) as ClaudeUsageResponse;
-const windows = [];
+  const windows = [];
 
   if (data.five_hour) {
     windows.push({
@@ -54,12 +70,35 @@ const windows = [];
   }
   if (data.seven_day) {
     windows.push({
-      label: "Weekly",
+      label: "Weekly · all models",
       usedPercent: Math.round(data.seven_day.utilization),
       resetsAt: formatResetTime(data.seven_day.resets_at),
     });
   }
+  if (data.seven_day_sonnet) {
+    windows.push({
+      label: "Weekly · Sonnet",
+      usedPercent: Math.round(data.seven_day_sonnet.utilization),
+      resetsAt: formatResetTime(data.seven_day_sonnet.resets_at),
+    });
+  }
+  if (data.seven_day_opus) {
+    windows.push({
+      label: "Weekly · Opus",
+      usedPercent: Math.round(data.seven_day_opus.utilization),
+      resetsAt: formatResetTime(data.seven_day_opus.resets_at),
+    });
+  }
+
+  // Pay-as-you-go: monthly_limit is cents, used_credits is dollars.
+  const extraUsage =
+    data.extra_usage?.is_enabled && data.extra_usage.monthly_limit > 0
+      ? {
+          usedDollars: data.extra_usage.used_credits,
+          monthlyLimitDollars: data.extra_usage.monthly_limit / 100,
+        }
+      : undefined;
 
   const email = await fetchClaudeEmail(sessionKey);
-  return { name: "Claude", plan: "Pro", status: "ok", windows, email, accountId: "" };
+  return { name: "Claude", plan: "Pro", status: "ok", windows, email, extraUsage, accountId: "" };
 }

--- a/src/lib/api/serviceStatus.ts
+++ b/src/lib/api/serviceStatus.ts
@@ -1,0 +1,92 @@
+import { fetch } from "@tauri-apps/plugin-http";
+import type { OperationalStatus, ServiceStatusInfo } from "@/types";
+
+/**
+ * Live operational status, pulled from each provider's public Statuspage.io feed.
+ * All endpoints are unauthenticated JSON. A fetch failure yields "unknown" — the
+ * UI treats it as "no data" rather than a fake green.
+ */
+
+type StatuspagePayload = {
+  status?: {
+    indicator?: "none" | "minor" | "major" | "critical";
+    description?: string;
+  };
+};
+
+/** Map Statuspage.io `indicator` to our 4-state operational status. */
+function mapIndicator(indicator: string | undefined): OperationalStatus {
+  switch (indicator) {
+    case "none":
+      return "operational";
+    case "minor":
+      return "degraded";
+    case "major":
+    case "critical":
+      return "outage";
+    default:
+      return "unknown";
+  }
+}
+
+type StatusSource = { api: string; page: string };
+
+const STATUS_SOURCES: Record<string, StatusSource> = {
+  claude: {
+    api: "https://status.anthropic.com/api/v2/status.json",
+    page: "https://status.anthropic.com",
+  },
+  chatgpt: {
+    api: "https://status.openai.com/api/v2/status.json",
+    page: "https://status.openai.com",
+  },
+  cursor: {
+    api: "https://status.cursor.com/api/v2/status.json",
+    page: "https://status.cursor.com",
+  },
+};
+
+async function fetchStatuspage(
+  source: StatusSource
+): Promise<ServiceStatusInfo> {
+  try {
+    const res = await fetch(source.api, { method: "GET" });
+    if (!res.ok) return { status: "unknown", page: source.page };
+    const data = (await res.json()) as StatuspagePayload;
+    return {
+      status: mapIndicator(data.status?.indicator),
+      description: data.status?.description,
+      page: source.page,
+    };
+  } catch {
+    return { status: "unknown", page: source.page };
+  }
+}
+
+/**
+ * Fetches the full operational status info for a single service by id.
+ * Returns `null` for unsupported services (e.g. Gemini — opted out of v1).
+ */
+export async function fetchOperationalStatus(
+  serviceId: string
+): Promise<ServiceStatusInfo | null> {
+  const source = STATUS_SOURCES[serviceId];
+  if (!source) return null;
+  return fetchStatuspage(source);
+}
+
+/**
+ * Fetches statuses for all supported services in parallel.
+ * Returns a map keyed by service id. Services not in the map are unsupported.
+ */
+export async function fetchAllOperationalStatuses(): Promise<
+  Record<string, ServiceStatusInfo>
+> {
+  const ids = Object.keys(STATUS_SOURCES);
+  const results = await Promise.all(
+    ids.map((id) => fetchStatuspage(STATUS_SOURCES[id]))
+  );
+  const out: Record<string, ServiceStatusInfo> = {};
+  for (let i = 0; i < ids.length; i++) out[ids[i]] = results[i];
+  return out;
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,19 +1,22 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import { RefreshCw } from "lucide-react";
 import { Card, CardContent } from "@/components/ui/card";
+import { Separator } from "@/components/ui/separator";
 import { loadCredentials } from "@/lib/credentials";
 import { fetchClaudeUsage } from "@/lib/api/claude";
 import { fetchChatGPTUsage } from "@/lib/api/chatgpt";
 import { fetchCursorUsage } from "@/lib/api/cursor";
 import { fetchGeminiUsage } from "@/lib/api/gemini";
+import { fetchAllOperationalStatuses } from "@/lib/api/serviceStatus";
 import { NextResetCard } from "@/components/dashboard/NextResetCard";
 import { ServiceDonutCard } from "@/components/dashboard/ServiceDonutCard";
+import { ServiceStatusPanel } from "@/components/dashboard/ServiceStatusPanel";
 import { notify, getJwtExpiry } from "@/lib/notify";
 import { SERVICES } from "@/lib/services";
 import { saveHistorySnapshot } from "@/lib/history";
 import History from "@/pages/History";
 import type { Account, CredentialsStore } from "@/lib/credentials";
-import type { ServiceData } from "@/types";
+import type { ServiceData, ServiceStatusInfo } from "@/types";
 
 type Props = { onNavigateToSettings?: () => void };
 
@@ -71,6 +74,7 @@ async function fetchAccount(
 
 export default function Dashboard({ onNavigateToSettings }: Props) {
   const [services, setServices] = useState<ServiceData[]>([]);
+  const [statusByService, setStatusByService] = useState<Record<string, ServiceStatusInfo>>({});
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
@@ -132,20 +136,28 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
         }
       }
 
-      const settled = await Promise.allSettled(
-        toFetch.map(({ serviceId, account, label }) =>
-          fetchAccount(serviceId, account, label)
-        )
-      );
+      // Kick off usage fetches and the status-page fetch in parallel — they're
+      // independent so a status-page outage shouldn't delay usage data.
+      const [settled, operationalByService] = await Promise.all([
+        Promise.allSettled(
+          toFetch.map(({ serviceId, account, label }) =>
+            fetchAccount(serviceId, account, label)
+          )
+        ),
+        fetchAllOperationalStatuses(),
+      ]);
+
+      setStatusByService(operationalByService);
 
       const results: ServiceData[] = settled.map((result, i) => {
         const { serviceId, account, label } = toFetch[i];
         const serviceName = SERVICES.find((s) => s.id === serviceId)?.name ?? serviceId;
-        if (result.status === "fulfilled") return result.value;
-        return { accountId: account.id, name: serviceName, label, plan: "", status: "error" as const, windows: [] };
+        const operational = operationalByService[serviceId]?.status;
+        if (result.status === "fulfilled") return { ...result.value, operational };
+        return { accountId: account.id, name: serviceName, label, plan: "", status: "error" as const, windows: [], operational };
       });
 
-      // Gemini CLI — file-based, not store-based
+      // Gemini CLI — file-based, not store-based. No operational status in v1.
       const geminiResult = await fetchGeminiUsage();
       if (geminiResult.status !== "not_configured") {
         results.push(geminiResult);
@@ -242,10 +254,25 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
               ))
             )}
           </div>
+
+          <Separator className="my-2" />
         </>
       )}
 
       <History />
+
+      {services.length > 0 && (
+        <>
+          <Separator className="my-2" />
+          <ServiceStatusPanel
+            integratedServiceIds={services.map((s) => {
+              // Map ServiceData.name back to service id for the panel lookup.
+              return SERVICES.find((svc) => svc.name === s.name)?.id ?? "";
+            }).filter(Boolean)}
+            statusByService={statusByService}
+          />
+        </>
+      )}
     </div>
   );
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,25 @@ export type UsageWindow = {
 
 export type ServiceStatus = "ok" | "expired" | "error" | "not_configured";
 
+/** Live operational status pulled from each provider's public status page. */
+export type OperationalStatus = "operational" | "degraded" | "outage" | "unknown";
+
+export type ServiceStatusInfo = {
+  status: OperationalStatus;
+  /** Human-readable status text from the provider (e.g. "All Systems Operational"). */
+  description?: string;
+  /** URL of the public status page. */
+  page: string;
+};
+
+/** Pay-as-you-go / top-up usage beyond the plan limits. Dollar amounts. */
+export type ExtraUsage = {
+  /** Amount already consumed this month. */
+  usedDollars: number;
+  /** Monthly cap the user has set. */
+  monthlyLimitDollars: number;
+};
+
 export type ServiceData = {
   accountId: string;
   name: string;
@@ -14,4 +33,6 @@ export type ServiceData = {
   status: ServiceStatus;
   windows: UsageWindow[];
   email?: string;
+  operational?: OperationalStatus;
+  extraUsage?: ExtraUsage;
 };


### PR DESCRIPTION
## Summary
- Closes [TOK-37](https://linear.app/mijeong-irene-ban/issue/TOK-37/service-status-feature-show-live-status-for-claude-codex-cursor-gemini) — live operational status for Claude, ChatGPT (Codex), and Cursor.
- Each service card gets a green/yellow/red dot next to the plan badge; full status list with click-through to each provider's public status page lives below History.
- Bonus: surfaces three more Claude usage fields (`seven_day_sonnet`, `seven_day_opus`, `extra_usage`) that were already in the API response but not displayed.

## How it works
- `src/lib/api/serviceStatus.ts` hits the three Statuspage.io `/api/v2/status.json` feeds in **parallel** with the existing usage fetch (`Promise.all`), so a status-page outage can't slow usage refresh.
- `indicator` → `operational | degraded | outage | unknown`, passed through both as a dot on each card and as the full `ServiceStatusPanel` row.
- Gemini is **opted out of v1** — `status.cloud.google.com` covers all of GCP and would be too noisy. Can revisit with a service-filter heuristic.
- Includes the docs update that adds the git-flow + Linear workflow + gstack sections to `CLAUDE.md` (first commit).

## Test plan
- [ ] Run `npm run tauri dev` and confirm status dots appear on each card
- [ ] Confirm the Service Status panel renders below History and opens the correct page on click
- [ ] Confirm Claude card now shows "Weekly · Sonnet" and "Extra usage" rows when the response includes them
- [ ] Temporarily break a status URL in `serviceStatus.ts` and confirm the card still renders (no dot, rest of UI unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)