### PR TITLE
fix(settings): stay on Settings after save (TOK-54)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -149,7 +149,6 @@ export default function App() {
           <Settings
             tab={settingsTab}
             onTabChange={setSettingsTab}
-            onSaved={() => setPage("dashboard")}
           />
         )}
 

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -50,7 +50,6 @@ type StatusMap = Record<string, "idle" | "saving" | "saved" | "expired" | "error
 type Props = {
   tab?: string;
   onTabChange?: (tab: string) => void;
-  onSaved?: () => void;
 };
 
 function isAccountConfigured(account: Account, fields: { key: string }[]): boolean {
@@ -72,7 +71,7 @@ function isPersistedAccountDeletable(persisted: CredentialsStore, serviceId: str
   return !hasAnyField; // show delete only if all fields are empty (broken state)
 }
 
-export default function Settings({ tab, onTabChange, onSaved }: Props) {
+export default function Settings({ tab, onTabChange }: Props) {
   const [persisted, setPersisted] = useState<CredentialsStore>({});
   const [draft, setDraft] = useState<CredentialsStore>({});
   const [statuses, setStatuses] = useState<StatusMap>({});
@@ -173,7 +172,6 @@ export default function Settings({ tab, onTabChange, onSaved }: Props) {
       setStatuses((prev) => ({ ...prev, [accountId]: "saved" }));
       setTimeout(() => {
         setStatuses((prev) => ({ ...prev, [accountId]: "idle" }));
-        onSaved?.();
       }, 800);
     } catch (e) {
       console.error("Failed to save credentials", e);


### PR DESCRIPTION
## Summary
- Removes the auto-redirect from Settings → Dashboard that fired 800ms after a successful save.
- The in-place "✓ Saved" / error states (already wired in `handleSave`) remain and are now the final resting state — users see whether the new token validated and stay where they are.
- Especially helpful when the user landed on Settings specifically to fix an expired token: they can now confirm the new token works without being teleported back to the dashboard.

Closes TOK-54.

## Test plan
- [ ] Expire a ChatGPT token → click **Fix** on the dashboard card → update the token → hit Save → "✓ Saved" appears and the page stays on the ChatGPT Settings tab.
- [ ] Saving invalid / expired new creds still shows "Token is expired or invalid" / "Failed — check your credentials" in the button.
- [ ] Saving fresh credentials (no prior expired token) also stays on Settings; the button reverts to "Save X credentials" after ~800ms.
- [ ] Header Dashboard button still navigates back normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)