### PR TITLE
fix(gemini): hide Pro models on free tier + per-model visibility toggle (#26)

### DIFF
--- a/src/lib/api/gemini.ts
+++ b/src/lib/api/gemini.ts
@@ -1,6 +1,11 @@
 import { fetch } from "@tauri-apps/plugin-http";
 import { readTextFile, exists, BaseDirectory } from "@tauri-apps/plugin-fs";
 import { formatResetTime } from "@/lib/api/utils";
+import {
+  loadPreferences,
+  isGeminiModelAutoHidden,
+  isGeminiModelVisible,
+} from "@/lib/preferences";
 import type { ServiceData } from "@/types";
 
 // ── OAuth constants (public, from open-source Gemini CLI) ─────────────────────
@@ -126,33 +131,38 @@ async function resolveAccessToken(): Promise<{ accessToken: string; idToken: str
   }
 }
 
-// ── Main export ───────────────────────────────────────────────────────────────
+// ── Shared fetch ──────────────────────────────────────────────────────────────
+//
+// Both the Dashboard (fetchGeminiUsage) and the Settings model-visibility UI
+// (fetchGeminiModels) need the same tier + buckets, so the network flow lives
+// in a single internal function. The two exports only diverge in how they
+// shape the response.
 
-export async function fetchGeminiUsage(): Promise<ServiceData> {
-  // Check credentials file exists (BaseDirectory.Home resolves ~ correctly)
+type GeminiRawResult =
+  | { status: "not_configured" }
+  | { status: "expired" }
+  | { status: "error"; tier?: string }
+  | { status: "ok"; tier: string; buckets: QuotaBucket[]; email?: string };
+
+async function fetchGeminiRaw(): Promise<GeminiRawResult> {
   const credsExist = await exists(CREDS_PATH, { baseDir: BaseDirectory.Home }).catch(() => false);
-  if (!credsExist) return notConfigured();
+  if (!credsExist) return { status: "not_configured" };
 
-  // Check auth type — skip api-key and vertex-ai accounts
   try {
     const settingsRaw = await readTextFile(SETTINGS_PATH, { baseDir: BaseDirectory.Home });
     const settings = JSON.parse(settingsRaw) as { authType?: string };
     if (settings.authType === "api-key" || settings.authType === "vertex-ai") {
-      return notConfigured();
+      return { status: "not_configured" };
     }
   } catch {
     // settings.json missing or unparseable — proceed (OAuth is the default)
   }
 
-  // Resolve access token (with refresh if needed)
   const tokenResult = await resolveAccessToken();
-  if (!tokenResult) {
-    return { accountId: "gemini", name: "Gemini CLI", plan: "", status: "expired", windows: [] };
-  }
+  if (!tokenResult) return { status: "expired" };
   const { accessToken, idToken } = tokenResult;
   const email = decodeJwtEmail(idToken);
 
-  // Step 1: loadCodeAssist — get tier + project ID
   let tier = "";
   let projectId = "";
   try {
@@ -171,17 +181,16 @@ export async function fetchGeminiUsage(): Promise<ServiceData> {
         },
       }),
     });
-    if (!res.ok) return errorResult();
+    if (!res.ok) return { status: "error" };
     const data = (await res.json()) as { tier?: string; cloudaicompanionProject?: string };
     tier = data.tier ?? "";
     projectId = data.cloudaicompanionProject ?? "";
   } catch {
-    return errorResult();
+    return { status: "error" };
   }
 
-  if (!projectId) return errorResult(tierToPlan(tier));
+  if (!projectId) return { status: "error", tier };
 
-  // Step 2: retrieveUserQuota — get per-model usage
   // Google's response uses `buckets` (was `quotaBuckets` in earlier API versions)
   let buckets: QuotaBucket[] = [];
   try {
@@ -193,21 +202,42 @@ export async function fetchGeminiUsage(): Promise<ServiceData> {
       },
       body: JSON.stringify({ project: projectId }),
     });
-    if (!res.ok) return errorResult(tierToPlan(tier));
+    if (!res.ok) return { status: "error", tier };
     const data = (await res.json()) as { buckets?: QuotaBucket[]; quotaBuckets?: QuotaBucket[] };
     buckets = data.buckets ?? data.quotaBuckets ?? [];
   } catch {
-    return errorResult(tierToPlan(tier));
+    return { status: "error", tier };
   }
 
-  // Map buckets to UsageWindows (Pro + Flash variants only)
-  const windows = buckets
-    .filter((b) => {
-      const id = b.modelId ?? b.model_id ?? "";
-      return id.includes("pro") || id.includes("flash");
-    })
+  return { status: "ok", tier, buckets, email };
+}
+
+function bucketModelId(b: QuotaBucket): string {
+  return b.modelId ?? b.model_id ?? "";
+}
+
+function isTrackedModel(id: string): boolean {
+  return id.includes("pro") || id.includes("flash");
+}
+
+// ── Main exports ──────────────────────────────────────────────────────────────
+
+export async function fetchGeminiUsage(): Promise<ServiceData> {
+  const raw = await fetchGeminiRaw();
+  if (raw.status === "not_configured") return notConfigured();
+  if (raw.status === "expired") return { accountId: "gemini", name: "Gemini CLI", plan: "", status: "expired", windows: [] };
+  if (raw.status === "error") return errorResult(tierToPlan(raw.tier ?? ""));
+
+  const trackedBuckets = raw.buckets.filter((b) => isTrackedModel(bucketModelId(b)));
+  if (trackedBuckets.length === 0) return errorResult(tierToPlan(raw.tier));
+
+  const prefs = await loadPreferences();
+  const visibility = prefs.geminiModelVisibility;
+
+  const windows = trackedBuckets
+    .filter((b) => isGeminiModelVisible(bucketModelId(b), raw.tier, visibility))
     .map((b) => {
-      const id = b.modelId ?? b.model_id ?? "";
+      const id = bucketModelId(b);
       const remaining = b.remainingFraction ?? b.remaining_fraction ?? 0;
       const resetIso = b.resetTime ?? b.reset_time ?? null;
       return {
@@ -217,14 +247,58 @@ export async function fetchGeminiUsage(): Promise<ServiceData> {
       };
     });
 
-  if (windows.length === 0) return errorResult(tierToPlan(tier));
-
+  // Zero windows here means the user has hidden every available model. Still
+  // surface "ok" so the card and the Settings model list stay reachable —
+  // NextResetCard and ServiceDonutCard both guard against empty windows.
   return {
     accountId: "gemini",
     name: "Gemini CLI",
-    plan: tierToPlan(tier),
+    plan: tierToPlan(raw.tier),
     status: "ok",
     windows,
-    email,
+    email: raw.email,
+  };
+}
+
+export type GeminiModelInfo = {
+  id: string;
+  label: string;
+  visible: boolean;
+  autoHidden: boolean;
+};
+
+export type GeminiModelsResult =
+  | { status: "not_configured" | "expired" | "error" }
+  | {
+      status: "ok";
+      tier: string;
+      plan: string;
+      email?: string;
+      models: GeminiModelInfo[];
+    };
+
+export async function fetchGeminiModels(): Promise<GeminiModelsResult> {
+  const raw = await fetchGeminiRaw();
+  if (raw.status !== "ok") return { status: raw.status };
+
+  const prefs = await loadPreferences();
+  const visibility = prefs.geminiModelVisibility;
+
+  const models: GeminiModelInfo[] = raw.buckets
+    .map((b) => bucketModelId(b))
+    .filter(isTrackedModel)
+    .map((id) => ({
+      id,
+      label: formatGeminiModelLabel(id),
+      visible: isGeminiModelVisible(id, raw.tier, visibility),
+      autoHidden: isGeminiModelAutoHidden(id, raw.tier),
+    }));
+
+  return {
+    status: "ok",
+    tier: raw.tier,
+    plan: tierToPlan(raw.tier),
+    email: raw.email,
+    models,
   };
 }

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -1,0 +1,58 @@
+import { load } from "@tauri-apps/plugin-store";
+
+// User preferences that aren't credentials — kept in a separate store file so
+// the credentials store stays focused on secrets and so these can be reset
+// independently if we ever add an "Erase preferences" action.
+export type Preferences = {
+  /**
+   * Explicit per-model visibility for Gemini. A missing entry means "follow
+   * the tier-based default" (see `isGeminiModelAutoHidden`). A present entry
+   * is a user override and always wins.
+   */
+  geminiModelVisibility?: Record<string, boolean>;
+};
+
+const FILE = "preferences.json";
+const KEY = "preferences";
+
+export async function loadPreferences(): Promise<Preferences> {
+  const store = await load(FILE, { autoSave: false, defaults: {} });
+  return (await store.get<Preferences>(KEY)) ?? {};
+}
+
+export async function savePreferences(prefs: Preferences): Promise<void> {
+  const store = await load(FILE, { autoSave: false, defaults: {} });
+  await store.set(KEY, prefs);
+  await store.save();
+}
+
+export async function setGeminiModelVisible(modelId: string, visible: boolean): Promise<Preferences> {
+  const prefs = await loadPreferences();
+  const next: Preferences = {
+    ...prefs,
+    geminiModelVisibility: { ...(prefs.geminiModelVisibility ?? {}), [modelId]: visible },
+  };
+  await savePreferences(next);
+  return next;
+}
+
+/**
+ * Models that are not available on the user's current tier should default to
+ * hidden so the dashboard and tray icon aren't pinned at 100% by buckets the
+ * user can't actually use. Right now this only covers the known case from
+ * issue #26 — free-tier users don't get Gemini Pro models.
+ */
+export function isGeminiModelAutoHidden(modelId: string, tier: string): boolean {
+  if (tier === "free-tier" && modelId.toLowerCase().includes("pro")) return true;
+  return false;
+}
+
+export function isGeminiModelVisible(
+  modelId: string,
+  tier: string,
+  visibility: Record<string, boolean> | undefined
+): boolean {
+  const explicit = visibility?.[modelId];
+  if (typeof explicit === "boolean") return explicit;
+  return !isGeminiModelAutoHidden(modelId, tier);
+}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -11,9 +11,11 @@ import { loadCredentials, saveCredentials } from "@/lib/credentials";
 import { fetchClaudeUsage } from "@/lib/api/claude";
 import { fetchChatGPTUsage } from "@/lib/api/chatgpt";
 import { fetchCursorUsage } from "@/lib/api/cursor";
-import { fetchGeminiUsage } from "@/lib/api/gemini";
+import { fetchGeminiModels } from "@/lib/api/gemini";
+import { setGeminiModelVisible } from "@/lib/preferences";
 import { exists, BaseDirectory } from "@tauri-apps/plugin-fs";
 import type { Account, CredentialsStore } from "@/lib/credentials";
+import type { GeminiModelInfo } from "@/lib/api/gemini";
 
 function PasswordInput({
   id, placeholder, value, onChange,
@@ -78,6 +80,8 @@ export default function Settings({ tab, onTabChange }: Props) {
   const [geminiDetected, setGeminiDetected] = useState(false);
   const [geminiStatus, setGeminiStatus] = useState<"idle" | "detecting" | "detected" | "not_found" | "unsupported_auth" | "expired" | "error">("idle");
   const [geminiEmail, setGeminiEmail] = useState<string | undefined>(undefined);
+  const [geminiTier, setGeminiTier] = useState<string>("");
+  const [geminiModels, setGeminiModels] = useState<GeminiModelInfo[]>([]);
 
   useEffect(() => {
     loadCredentials().then((creds) => {
@@ -94,7 +98,18 @@ export default function Settings({ tab, onTabChange }: Props) {
   useEffect(() => {
     // tauri-plugin-fs does NOT expand ~ — use BaseDirectory.Home with a relative path
     exists(".gemini/oauth_creds.json", { baseDir: BaseDirectory.Home })
-      .then((found) => setGeminiDetected(found))
+      .then(async (found) => {
+        setGeminiDetected(found);
+        if (!found) return;
+        // Quietly load models so the visibility checkboxes appear on Settings
+        // without requiring the user to press Detect each time.
+        const result = await fetchGeminiModels();
+        if (result.status === "ok") {
+          setGeminiEmail(result.email);
+          setGeminiTier(result.tier);
+          setGeminiModels(result.models);
+        }
+      })
       .catch(() => setGeminiDetected(false));
   }, []);
 
@@ -182,19 +197,33 @@ export default function Settings({ tab, onTabChange }: Props) {
   async function handleDetect() {
     setGeminiStatus("detecting");
     setGeminiEmail(undefined);
-    const result = await fetchGeminiUsage();
+    const result = await fetchGeminiModels();
     if (result.status === "ok") {
       setGeminiStatus("detected");
       setGeminiEmail(result.email);
+      setGeminiTier(result.tier);
+      setGeminiModels(result.models);
       setGeminiDetected(true);
     } else if (result.status === "not_configured") {
       setGeminiStatus("not_found");
       setGeminiDetected(false);
+      setGeminiModels([]);
     } else if (result.status === "expired") {
       setGeminiStatus("expired");
+      setGeminiModels([]);
     } else {
       setGeminiStatus("error");
+      setGeminiModels([]);
     }
+  }
+
+  async function toggleGeminiModel(modelId: string, visible: boolean) {
+    // Optimistic update — the store write is local-only and effectively
+    // synchronous, but the UI responds immediately either way.
+    setGeminiModels((prev) =>
+      prev.map((m) => (m.id === modelId ? { ...m, visible } : m))
+    );
+    await setGeminiModelVisible(modelId, visible);
   }
 
   return (
@@ -364,6 +393,40 @@ export default function Settings({ tab, onTabChange }: Props) {
                 <p className="text-xs text-destructive">
                   Could not fetch Gemini quota. Check your connection and try again.
                 </p>
+              )}
+
+              {geminiDetected && geminiModels.length > 0 && (
+                <div className="space-y-2 pt-2 border-t border-border/50">
+                  <div>
+                    <p className="text-xs font-medium">Visible models</p>
+                    <p className="text-xs text-muted-foreground leading-relaxed mt-0.5">
+                      Hidden models don't appear on the Dashboard and don't
+                      affect the menu bar warning indicator.
+                      {geminiTier === "free-tier" && " Pro models are hidden by default because they're not available on the free tier."}
+                    </p>
+                  </div>
+                  <div className="space-y-1.5">
+                    {geminiModels.map((model) => (
+                      <label
+                        key={model.id}
+                        className="flex items-center gap-2 text-xs cursor-pointer select-none py-1"
+                      >
+                        <input
+                          type="checkbox"
+                          checked={model.visible}
+                          onChange={(e) => toggleGeminiModel(model.id, e.target.checked)}
+                          className="h-3.5 w-3.5 rounded border-border accent-primary"
+                        />
+                        <span>{model.label}</span>
+                        {model.autoHidden && (
+                          <span className="text-muted-foreground/70 text-[10px]">
+                            not on free tier
+                          </span>
+                        )}
+                      </label>
+                    ))}
+                  </div>
+                </div>
               )}
             </CardContent>
           </Card>


### PR DESCRIPTION
## Summary
Free-tier Gemini users don't have access to Pro models, but the quota API still returns Pro buckets at 0% remaining. The dashboard was rendering those as 100% used and the menu bar tray icon went red even though the user had no way to use those models (reported in #26).

- **Tier-based default** — on `free-tier`, any model whose id contains `pro` is auto-hidden from the Dashboard and excluded from the tray max-usage calculation. Zero-config fix for the reported case.
- **Per-model override** — Settings → Gemini CLI now lists detected models with checkboxes. Explicit choices persist to a new `preferences.json` store and always win over the tier-based default, so:
  - Paid users can hide models they don't use.
  - Free users can still opt in to showing Pro if they want to see the 100%.
  - If Google ever changes tier semantics, users have an escape hatch without a code change.

## Implementation notes
- New `src/lib/preferences.ts` wraps `tauri-plugin-store` with a `preferences.json` file, keeping secrets out of the credentials store.
- `gemini.ts` refactored: the network flow (token → loadCodeAssist → retrieveUserQuota) now lives in a shared `fetchGeminiRaw()` so both `fetchGeminiUsage()` (Dashboard) and `fetchGeminiModels()` (Settings UI) consume the same data.
- Visibility helpers (`isGeminiModelAutoHidden`, `isGeminiModelVisible`) live in `preferences.ts` so they're one source of truth for both the filter on fetch and the checkbox default in Settings.
- Settings auto-loads the model list on mount if Gemini creds exist, so the checkboxes appear without a Detect click.

## Test plan
- [ ] Free-tier Gemini: Dashboard no longer shows Pro cards; tray goes green; Settings shows Pro unchecked with "not on free tier" hint.
- [ ] Free-tier user checks the Pro box in Settings → Dashboard refresh shows Pro at 100% again; unchecking removes it.
- [ ] Paid-tier (standard-tier) Gemini: all Pro + Flash models visible by default; unchecking one hides it from Dashboard and tray calc after next refresh.
- [ ] Preferences persist across app restart.
- [ ] User with no Gemini creds: Settings Gemini tab still shows the Detect button; no model list.

## Follow-ups (not in this PR)
- Dashboard doesn't live-refresh on toggle — user sees the change at next 5-min fetch or via manual Refresh. Could wire a broadcast if we want instant feedback.
- No "reset to default" button for a model — once explicit, always explicit. Easy to add later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)