### PR TITLE
chore: simplify recent changes from /simplify review

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,9 +30,8 @@ function parseHash(hash: string): { page: Page; settingsTab: string } {
 }
 
 export default function App() {
-  const initial = parseHash(typeof window !== "undefined" ? window.location.hash : "");
-  const [page, setPage] = useState<Page>(initial.page);
-  const [settingsTab, setSettingsTab] = useState<string>(initial.settingsTab);
+  const [page, setPage] = useState<Page>(() => parseHash(window.location.hash).page);
+  const [settingsTab, setSettingsTab] = useState<string>(() => parseHash(window.location.hash).settingsTab);
   const { theme, cycleTheme } = useTheme();
   const rootRef = useRef<HTMLDivElement>(null);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);

--- a/src/lib/api/gemini.ts
+++ b/src/lib/api/gemini.ts
@@ -1,12 +1,10 @@
 import { fetch } from "@tauri-apps/plugin-http";
 import { readTextFile, exists, BaseDirectory } from "@tauri-apps/plugin-fs";
 import { formatResetTime } from "@/lib/api/utils";
-import {
-  loadPreferences,
-  isGeminiModelAutoHidden,
-  isGeminiModelVisible,
-} from "@/lib/preferences";
+import { loadPreferences } from "@/lib/preferences";
 import type { ServiceData } from "@/types";
+
+export const GEMINI_FREE_TIER = "free-tier";
 
 // ── OAuth constants (public, from open-source Gemini CLI) ─────────────────────
 // Source: https://github.com/google-gemini/gemini-cli
@@ -55,10 +53,27 @@ function decodeJwtEmail(idToken: string): string | undefined {
 }
 
 function tierToPlan(tier: string): string {
-  if (tier === "free-tier") return "Free";
+  if (tier === GEMINI_FREE_TIER) return "Free";
   if (tier === "standard-tier") return "Paid";
   if (tier === "legacy-tier") return "Legacy";
   return "";
+}
+
+// Models that are not available on the user's current tier default to hidden
+// so the dashboard and tray icon aren't pinned at 100% by buckets the user
+// can't actually use (issue #26 — free-tier users don't get Gemini Pro).
+export function isGeminiModelAutoHidden(modelId: string, tier: string): boolean {
+  return tier === GEMINI_FREE_TIER && modelId.toLowerCase().includes("pro");
+}
+
+export function isGeminiModelVisible(
+  modelId: string,
+  tier: string,
+  visibility: Record<string, boolean> | undefined
+): boolean {
+  const explicit = visibility?.[modelId];
+  if (typeof explicit === "boolean") return explicit;
+  return !isGeminiModelAutoHidden(modelId, tier);
 }
 
 // "gemini-2.5-flash-lite" → "2.5 Flash Lite", "gemini-3-flash-preview" → "3 Flash Preview"
@@ -132,11 +147,6 @@ async function resolveAccessToken(): Promise<{ accessToken: string; idToken: str
 }
 
 // ── Shared fetch ──────────────────────────────────────────────────────────────
-//
-// Both the Dashboard (fetchGeminiUsage) and the Settings model-visibility UI
-// (fetchGeminiModels) need the same tier + buckets, so the network flow lives
-// in a single internal function. The two exports only diverge in how they
-// shape the response.
 
 type GeminiRawResult =
   | { status: "not_configured" }

--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -35,24 +35,3 @@ export async function setGeminiModelVisible(modelId: string, visible: boolean): 
   await savePreferences(next);
   return next;
 }
-
-/**
- * Models that are not available on the user's current tier should default to
- * hidden so the dashboard and tray icon aren't pinned at 100% by buckets the
- * user can't actually use. Right now this only covers the known case from
- * issue #26 — free-tier users don't get Gemini Pro models.
- */
-export function isGeminiModelAutoHidden(modelId: string, tier: string): boolean {
-  if (tier === "free-tier" && modelId.toLowerCase().includes("pro")) return true;
-  return false;
-}
-
-export function isGeminiModelVisible(
-  modelId: string,
-  tier: string,
-  visibility: Record<string, boolean> | undefined
-): boolean {
-  const explicit = visibility?.[modelId];
-  if (typeof explicit === "boolean") return explicit;
-  return !isGeminiModelAutoHidden(modelId, tier);
-}

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -11,7 +11,7 @@ import { loadCredentials, saveCredentials } from "@/lib/credentials";
 import { fetchClaudeUsage } from "@/lib/api/claude";
 import { fetchChatGPTUsage } from "@/lib/api/chatgpt";
 import { fetchCursorUsage } from "@/lib/api/cursor";
-import { fetchGeminiModels } from "@/lib/api/gemini";
+import { fetchGeminiModels, GEMINI_FREE_TIER } from "@/lib/api/gemini";
 import { setGeminiModelVisible } from "@/lib/preferences";
 import { exists, BaseDirectory } from "@tauri-apps/plugin-fs";
 import type { Account, CredentialsStore } from "@/lib/credentials";
@@ -97,20 +97,23 @@ export default function Settings({ tab, onTabChange }: Props) {
 
   useEffect(() => {
     // tauri-plugin-fs does NOT expand ~ — use BaseDirectory.Home with a relative path
-    exists(".gemini/oauth_creds.json", { baseDir: BaseDirectory.Home })
-      .then(async (found) => {
-        setGeminiDetected(found);
-        if (!found) return;
-        // Quietly load models so the visibility checkboxes appear on Settings
-        // without requiring the user to press Detect each time.
-        const result = await fetchGeminiModels();
-        if (result.status === "ok") {
-          setGeminiEmail(result.email);
-          setGeminiTier(result.tier);
-          setGeminiModels(result.models);
-        }
-      })
-      .catch(() => setGeminiDetected(false));
+    Promise.all([
+      exists(".gemini/oauth_creds.json", { baseDir: BaseDirectory.Home }).catch(() => false),
+      fetchGeminiModels(),
+    ]).then(([found, result]) => {
+      setGeminiDetected(found);
+      if (!found) return;
+      if (result.status === "ok") {
+        setGeminiStatus("detected");
+        setGeminiEmail(result.email);
+        setGeminiTier(result.tier);
+        setGeminiModels(result.models);
+      } else if (result.status === "expired") {
+        setGeminiStatus("expired");
+      } else if (result.status === "error") {
+        setGeminiStatus("error");
+      }
+    });
   }, []);
 
   function setAccountField(serviceId: string, accountId: string, key: string, value: string) {
@@ -218,8 +221,6 @@ export default function Settings({ tab, onTabChange }: Props) {
   }
 
   async function toggleGeminiModel(modelId: string, visible: boolean) {
-    // Optimistic update — the store write is local-only and effectively
-    // synchronous, but the UI responds immediately either way.
     setGeminiModels((prev) =>
       prev.map((m) => (m.id === modelId ? { ...m, visible } : m))
     );
@@ -402,7 +403,7 @@ export default function Settings({ tab, onTabChange }: Props) {
                     <p className="text-xs text-muted-foreground leading-relaxed mt-0.5">
                       Hidden models don't appear on the Dashboard and don't
                       affect the menu bar warning indicator.
-                      {geminiTier === "free-tier" && " Pro models are hidden by default because they're not available on the free tier."}
+                      {geminiTier === GEMINI_FREE_TIER && " Pro models are hidden by default because they're not available on the free tier."}
                     </p>
                   </div>
                   <div className="space-y-1.5">


### PR DESCRIPTION
## Summary
- **App.tsx**: drop unnecessary `typeof window` guard (Tauri always has window) and use lazy `useState` initializers so `parseHash` doesn't run on every render.
- **gemini.ts**: own the Gemini visibility helpers (`isGeminiModelAutoHidden`, `isGeminiModelVisible`) — they're Gemini domain logic, not generic preferences. Add `GEMINI_FREE_TIER` constant to replace stringly-typed tier checks. Drop the change-narrating block comment.
- **Settings.tsx**: parallelize the mount-time `exists()` + `fetchGeminiModels()` (independent calls), surface `expired`/`error` from the mount path so users get feedback instead of a silently empty model list, drop the outdated "Optimistic update" what-comment, and consume the new `GEMINI_FREE_TIER` constant.

## Test plan
- [ ] `npm run build` succeeds (typecheck + bundle).
- [ ] Open Settings → Gemini tab on first load: if creds exist, models render with correct visibility; if creds expired, "Session expired" message shows.
- [ ] Toggling a model checkbox persists across reload.
- [ ] Free-tier user still sees "Pro models are hidden by default…" copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)