### PR TITLE
feat(web): announcement banner for new version releases

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,9 +57,10 @@ The app and the marketing site live in the same repo but are independent:
 The site's top-of-page announcement banner is driven by the **GitHub release body**, not a config file or a redeploy. To turn it on for a release, add a marker line to that release's notes:
 
 ```
-<!-- banner: Per-model visibility for Gemini, plus free-tier fixes. -->
+<!-- banner: There's a new uso.ai — see what's new. -->
 ```
 
+- **Default to the generic copy above** — it pairs naturally with the "Release notes →" CTA and works for every release. Customize only when a release has a single headline change worth featuring.
 - The marketing site re-fetches the release hourly (`revalidate: 3600` in `web/src/lib/github.ts`), so banner copy updates within ~1h of editing the release notes — no redeploy needed.
 - No marker = no banner. Use `<!-- banner: off -->` to explicitly suppress.
 - Keep blurbs short (~50–60 chars) so they fit on mobile without truncation.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,10 +38,10 @@ src-tauri/
 web/              — marketing site (uso.ai) — separate Next.js app in the same repo
   src/app/        — App Router pages, layout, sitemap, robots, OG image
   src/components/
-    sections/     — Hero, Product, Features, Download, Footer, Nav
+    sections/     — AnnouncementBanner, Hero, Product, Features, Download, Footer, Nav
     ui/           — Logo (wordmark), Button
   src/lib/
-    github.ts     — fetch latest release DMG URL at build time
+    github.ts     — fetch latest release (DMG URL, version, banner blurb) at build time, revalidated hourly
     utils.ts      — cn() helper
   package.json    — pnpm, Next.js 16, React 19, Tailwind v4
 ```
@@ -52,6 +52,20 @@ The app and the marketing site live in the same repo but are independent:
 - The marketing site uses `pnpm` and lives at `web/`.
 - Don't run `pnpm` at the root or `npm install` inside `web/`.
 - Deploy the marketing site from `web/` as its own Vercel project.
+
+### Marketing announcement banner
+The site's top-of-page announcement banner is driven by the **GitHub release body**, not a config file or a redeploy. To turn it on for a release, add a marker line to that release's notes:
+
+```
+<!-- banner: Per-model visibility for Gemini, plus free-tier fixes. -->
+```
+
+- The marketing site re-fetches the release hourly (`revalidate: 3600` in `web/src/lib/github.ts`), so banner copy updates within ~1h of editing the release notes — no redeploy needed.
+- No marker = no banner. Use `<!-- banner: off -->` to explicitly suppress.
+- Keep blurbs short (~50–60 chars) so they fit on mobile without truncation.
+- Dismissals are keyed by version in `localStorage`, so a new release re-shows the banner for everyone.
+
+The `/release` skill (`.claude/skills/release/SKILL.md` Step 3) prompts you to include a marker when writing release notes.
 
 ## Commands
 ```bash

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { getLatestRelease } from "@/lib/github";
+import { AnnouncementBanner } from "@/components/sections/AnnouncementBanner";
 import { Nav } from "@/components/sections/Nav";
 import { Hero } from "@/components/sections/Hero";
 import { Product } from "@/components/sections/Product";
@@ -11,6 +12,13 @@ export default async function HomePage() {
 
   return (
     <>
+      {release.bannerBlurb && (
+        <AnnouncementBanner
+          version={release.version}
+          blurb={release.bannerBlurb}
+          releaseUrl={release.releaseUrl}
+        />
+      )}
       <Nav dmgUrl={release.dmgUrl} />
       <main>
         <Hero release={release} />

--- a/web/src/components/sections/AnnouncementBanner.tsx
+++ b/web/src/components/sections/AnnouncementBanner.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import Link from "next/link";
+import { useSyncExternalStore } from "react";
+
+type Props = {
+  version: string;
+  blurb: string;
+  releaseUrl: string;
+};
+
+const STORAGE_PREFIX = "uso-banner-dismissed:";
+
+// In-tab listeners so click-to-dismiss updates the UI immediately.
+// (The native `storage` event only fires across tabs, not in the same one.)
+const listeners = new Set<() => void>();
+
+function subscribe(cb: () => void) {
+  listeners.add(cb);
+  const onStorage = () => cb();
+  window.addEventListener("storage", onStorage);
+  return () => {
+    listeners.delete(cb);
+    window.removeEventListener("storage", onStorage);
+  };
+}
+
+function notify() {
+  for (const cb of listeners) cb();
+}
+
+function readDismissed(version: string): boolean {
+  try {
+    return localStorage.getItem(STORAGE_PREFIX + version) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function AnnouncementBanner({ version, blurb, releaseUrl }: Props) {
+  const dismissed = useSyncExternalStore(
+    subscribe,
+    () => readDismissed(version),
+    // SSR + initial client render: assume not dismissed so the banner is in the
+    // DOM by default. React swaps to the real value on the next paint without a
+    // hydration warning.
+    () => false,
+  );
+
+  if (dismissed) return null;
+
+  const handleDismiss = () => {
+    try {
+      localStorage.setItem(STORAGE_PREFIX + version, "1");
+    } catch {
+      // Storage unavailable — dismissal won't persist across reloads.
+    }
+    notify();
+  };
+
+  return (
+    <div
+      role="region"
+      aria-label="Latest release announcement"
+      className="relative z-40 border-b border-border-subtle bg-gradient-to-r from-brand/15 via-brand-violet/15 to-brand/15"
+    >
+      <div className="mx-auto flex max-w-6xl items-center gap-3 px-6 py-2.5 text-[13px] sm:text-[14px]">
+        <span className="hidden shrink-0 items-center gap-1.5 rounded-full border border-border-default bg-white/[0.04] px-2 py-0.5 text-[12px] font-medium text-text-primary sm:inline-flex">
+          <span className="size-1.5 rounded-full bg-status-green" />
+          {version}
+        </span>
+        <span className="min-w-0 flex-1 truncate text-text-secondary">
+          <span className="inline font-medium text-text-primary sm:hidden">
+            {version}
+          </span>
+          <span className="mx-1.5 inline text-text-subtle sm:hidden">·</span>
+          {blurb}
+        </span>
+        <Link
+          href={releaseUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="shrink-0 whitespace-nowrap text-[13px] font-medium text-text-primary underline-offset-4 hover:underline sm:text-[14px]"
+        >
+          Release notes →
+        </Link>
+        <button
+          type="button"
+          onClick={handleDismiss}
+          aria-label="Dismiss announcement"
+          className="shrink-0 rounded-md p-1 text-text-muted transition-colors hover:bg-white/[0.06] hover:text-text-primary"
+        >
+          <svg
+            width="14"
+            height="14"
+            viewBox="0 0 14 14"
+            fill="none"
+            aria-hidden
+          >
+            <path
+              d="M3 3l8 8M11 3l-8 8"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              strokeLinecap="round"
+            />
+          </svg>
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/lib/github.ts
+++ b/web/src/lib/github.ts
@@ -14,12 +14,20 @@ export interface LatestRelease {
   version: string;
   dmgUrl: string | null;
   releaseUrl: string;
+  /**
+   * Short blurb for the announcement banner, parsed from a
+   * `<!-- banner: ... -->` marker in the release body.
+   * Lets release authors update banner copy by editing the GitHub release —
+   * no code change or redeploy needed.
+   */
+  bannerBlurb: string | null;
 }
 
 const FALLBACK: LatestRelease = {
   version: "latest",
   dmgUrl: null,
   releaseUrl: `https://github.com/${REPO}/releases/latest`,
+  bannerBlurb: null,
 };
 
 export async function getLatestRelease(): Promise<LatestRelease> {
@@ -34,6 +42,7 @@ export async function getLatestRelease(): Promise<LatestRelease> {
     const data = (await res.json()) as {
       tag_name: string;
       html_url: string;
+      body?: string | null;
       assets: Array<{ name: string; browser_download_url: string }>;
     };
 
@@ -43,8 +52,18 @@ export async function getLatestRelease(): Promise<LatestRelease> {
       version: data.tag_name,
       dmgUrl: dmg?.browser_download_url ?? null,
       releaseUrl: data.html_url,
+      bannerBlurb: extractBannerBlurb(data.body),
     };
   } catch {
     return FALLBACK;
   }
+}
+
+function extractBannerBlurb(body: string | null | undefined): string | null {
+  if (!body) return null;
+  const match = body.match(/<!--\s*banner:\s*([\s\S]+?)\s*-->/i);
+  if (!match) return null;
+  const text = match[1].trim();
+  if (!text || text.toLowerCase() === "off") return null;
+  return text;
 }


### PR DESCRIPTION
Resolves [TOK-58](https://linear.app/mijeong-irene-ban/issue/TOK-58/add-announcement-banner-to-marketing-site-for-new-version-releases).

## Summary
- New `AnnouncementBanner` sits above `<Nav>` on the marketing site, showing the latest version + a short blurb + a link to the GitHub release notes.
- Dismissible per visitor via `localStorage`, keyed by version (`uso-banner-dismissed:<version>`) so a new release re-shows it for everyone.
- Copy is sourced from a `<!-- banner: ... -->` marker in the latest GitHub release body — no redeploy needed to update it; the existing hourly `revalidate` picks up changes. Omit the marker (or use `<!-- banner: off -->`) to hide the banner entirely.

## How copy is edited (no redeploy)
In the GitHub release body, add e.g.:
```
<!-- banner: Per-model visibility for Gemini, plus free-tier fixes. -->
```
The site re-fetches the release every hour, so the banner updates within ~1h of editing the release notes.

## Implementation notes
- `AnnouncementBanner` is a Client Component using `useSyncExternalStore` to sync dismissal state with `localStorage` (the React 19-correct pattern, no flash for first-time visitors and no `setState`-in-effect lint violation).
- `getLatestRelease()` extended with `bannerBlurb`, parsed from the release body. Backward-compatible — falls back to `null`.
- Banner only renders when `bannerBlurb` is truthy, so the page is unchanged for releases without a banner marker (which is the case for the current `v1.6.0` release).

## Acceptance criteria
- [x] Banner sits above the fold (top of marketing site, above `<Nav>`).
- [x] Shows version number + short blurb + link to release notes.
- [x] Dismissible per visitor; dismissal is keyed by version so it doesn't nag.
- [x] Easy to update copy without a redeploy (release-body marker, hourly revalidation).
- [x] Responsive: version pill hidden on mobile (inlined into the blurb prefix); long blurbs truncate with ellipsis.

## Test plan
- [ ] Add a test marker to a draft release body (or set the latest release body to include `<!-- banner: ... -->`); confirm the banner appears within ~1h on production.
- [ ] Click "Release notes →" — should open the GitHub release in a new tab.
- [ ] Click the X — banner disappears for the current version. Reload — stays dismissed.
- [ ] Bump the release (or change the version in the marker) — banner re-appears.
- [ ] Inspect at mobile width (≤640px) — banner reads cleanly without overflow; version moves into the blurb prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)