### PR TITLE
fix: weekly reset says "today" when it means "tomorrow" (#31)

### DIFF
--- a/src/lib/api/chatgpt.ts
+++ b/src/lib/api/chatgpt.ts
@@ -1,5 +1,6 @@
 import { fetch } from "@tauri-apps/plugin-http";
 import type { ServiceData } from "@/types";
+import { calendarDayDiff } from "./utils";
 
 type RateLimitWindow = {
   used_percent: number;
@@ -31,10 +32,10 @@ function formatResetSeconds(seconds: number): string {
     return m > 0 ? `in ${h}h ${m}m` : `in ${h}h`;
   }
   const resetDate = new Date(Date.now() + seconds * 1000);
-  const dayDiff = Math.floor(seconds / 86400);
+  const days = calendarDayDiff(resetDate, new Date());
   const timeStr = resetDate.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
-  if (dayDiff === 0) return `today ${timeStr}`;
-  if (dayDiff === 1) return `tomorrow ${timeStr}`;
+  if (days === 0) return `today ${timeStr}`;
+  if (days === 1) return `tomorrow ${timeStr}`;
   return resetDate.toLocaleDateString("en-US", { month: "short", day: "numeric" });
 }
 

--- a/src/lib/api/utils.ts
+++ b/src/lib/api/utils.ts
@@ -1,7 +1,7 @@
 /**
  * Formats an ISO 8601 reset timestamp into a human-readable string.
  * Returns "—" for null/missing values.
- * Examples: "in 45m", "in 2h 30m", "today 3:00 PM", "Mon 9:00 AM"
+ * Examples: "in 45m", "in 2h 30m", "today 3:00 PM", "tomorrow 4:00 AM", "Mon 9:00 AM"
  */
 export function formatResetTime(isoString: string | null): string {
   if (!isoString) return "—";
@@ -21,8 +21,25 @@ export function formatResetTime(isoString: string | null): string {
   }
 
   const timeStr = date.toLocaleTimeString("en-US", { hour: "numeric", minute: "2-digit" });
-  const dayDiff = Math.floor(diffMs / 86400000);
-  if (dayDiff === 0) return `today ${timeStr}`;
+  const days = calendarDayDiff(date, new Date());
+  if (days === 0) return `today ${timeStr}`;
+  if (days === 1) return `tomorrow ${timeStr}`;
   const dayName = date.toLocaleDateString("en-US", { weekday: "short" });
   return `${dayName} ${timeStr}`;
+}
+
+/**
+ * Calendar-day diff between two dates (target − from), in the local timezone.
+ * Returns the integer number of midnights crossed: 0 = same calendar date,
+ * 1 = next calendar day, etc. (negative if `target` is in the past).
+ *
+ * Don't compute this from a duration like `Math.floor(diffMs / 86400000)` —
+ * that measures 24-hour periods, not midnights, so a Sunday 4am reset viewed
+ * from Saturday 10pm comes out as 0 days (≈0.25) and gets mislabeled "today"
+ * instead of "tomorrow". (uso.ai#31)
+ */
+export function calendarDayDiff(target: Date, from: Date): number {
+  const a = new Date(from.getFullYear(), from.getMonth(), from.getDate()).getTime();
+  const b = new Date(target.getFullYear(), target.getMonth(), target.getDate()).getTime();
+  return Math.round((b - a) / 86400000);
 }


### PR DESCRIPTION
Closes #31.

## The bug
`formatResetTime` in `src/lib/api/utils.ts` (and the matching path in `src/lib/api/chatgpt.ts`) computed "today vs. tomorrow" with `Math.floor(diffMs / 86400000)` — i.e. *24-hour periods elapsed*, not *midnights crossed*. So at Saturday 10pm, a Sunday 4am reset is ~6h away (≈0.25 days), `Math.floor` rounds that to 0, and the UI labels it `today 4 AM` when it should be `tomorrow 4 AM`.

That's exactly the symptom in the screenshot on #31: it's late evening, the weekly reset is the next morning, and the dashboard says "today 4am".

## The fix
New `calendarDayDiff(target, from)` helper in `utils.ts` that snaps both dates to local midnight before subtracting, so the result is the true number of calendar days between them.

- `utils.ts` `formatResetTime`: uses `calendarDayDiff` and now has an explicit `"tomorrow"` branch (previously fell through to the weekday name for any non-today day, so `Sun 4:00 AM` shipped instead of `tomorrow 4:00 AM`).
- `chatgpt.ts` `formatResetSeconds`: imports the same helper and replaces its equivalent `Math.floor(seconds / 86400)` bug.

## Verified
Spot-check against six cases (including the exact bug scenario):

| from | target | got | expected |
|---|---|---|---|
| Sat 10pm | Sun 4am (the bug) | 1 | 1 ✅ |
| Sun 3am | Sun 4am (true today) | 0 | 0 ✅ |
| Sun noon | Sun 11:59pm | 0 | 0 ✅ |
| Sun 11pm | Mon 1am | 1 | 1 ✅ |
| Sun → Tue | (2 days) | 2 | 2 ✅ |
| Sun → next Sun | (7 days) | 7 | 7 ✅ |

Type-check (`npx tsc --noEmit`) passes.

## Test plan
- [ ] Open the dashboard the evening before a Claude weekly reset; confirm it now shows "tomorrow 4 AM" instead of "today 4 AM".
- [ ] Mid-day on the reset day, confirm it still shows "today 4 AM".
- [ ] ChatGPT card with a >6h, <24h reset that crosses midnight: same behaviour.
- [ ] Reset 2+ days out: still shows weekday name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)