### PR TITLE
feat: dashboard variety improvements (Claude Design + ChatGPT Go + Cursor unlimited & PAYG)

### DIFF
--- a/src/lib/api/chatgpt.ts
+++ b/src/lib/api/chatgpt.ts
@@ -75,7 +75,11 @@ export async function fetchChatGPTUsage(bearerToken: string): Promise<ServiceDat
   }
 
   const data = (await res.json()) as ChatGPTUsageResponse;
-const plan = data.plan_type === "plus" ? "Plus" : data.plan_type;
+  // Capitalize whatever OpenAI returns ("plus" → "Plus", "go" → "Go", etc.)
+  // so new tier names auto-format correctly without code changes.
+  const plan = data.plan_type
+    ? data.plan_type.charAt(0).toUpperCase() + data.plan_type.slice(1)
+    : data.plan_type;
   const windows = [];
 
   const primary = data.rate_limit?.primary_window;

--- a/src/lib/api/claude.ts
+++ b/src/lib/api/claude.ts
@@ -12,6 +12,12 @@ type ClaudeUsageResponse = {
   /** "Weekly · Opus only" bucket — only populated on plans with an Opus-specific limit. */
   seven_day_opus?: UsageBucket;
   /**
+   * "Weekly · Claude Design" bucket. Anthropic's internal codename for the
+   * Claude Design feature is `omelette` — confirmed by matching the 0% reading
+   * on this field against the Claude Design row in claude.ai → Settings → Usage.
+   */
+  seven_day_omelette?: UsageBucket;
+  /**
    * Pay-as-you-go spend. `monthly_limit` is returned in **cents**,
    * `used_credits` is returned in **dollars** (float).
    */
@@ -21,6 +27,9 @@ type ClaudeUsageResponse = {
     used_credits: number;
     utilization: number | null;
   };
+  // Other observed buckets we don't surface yet because their UI mapping is
+  // unconfirmed (all null in the sample we have): seven_day_oauth_apps,
+  // seven_day_cowork, omelette_promotional, tangelo, iguana_necktie.
 };
 
 async function fetchClaudeEmail(sessionKey: string): Promise<string | undefined> {
@@ -87,6 +96,13 @@ export async function fetchClaudeUsage(
       label: "Weekly · Opus",
       usedPercent: Math.round(data.seven_day_opus.utilization),
       resetsAt: formatResetTime(data.seven_day_opus.resets_at),
+    });
+  }
+  if (data.seven_day_omelette) {
+    windows.push({
+      label: "Weekly · Claude Design",
+      usedPercent: Math.round(data.seven_day_omelette.utilization),
+      resetsAt: formatResetTime(data.seven_day_omelette.resets_at),
     });
   }
 

--- a/src/lib/api/cursor.ts
+++ b/src/lib/api/cursor.ts
@@ -5,6 +5,11 @@ type CursorUsageResponse = {
   membershipType: string;
   billingCycleStart: string;
   billingCycleEnd: string;
+  /**
+   * True for plans with no per-cycle quota cap. When true, percent-used
+   * fields are 0 / meaningless — show the plan badge but no usage bars.
+   */
+  isUnlimited?: boolean;
   individualUsage: {
     plan: {
       autoPercentUsed: number;
@@ -51,10 +56,26 @@ export async function fetchCursorUsage(sessionToken: string): Promise<ServiceDat
   }
 
   const data = (await res.json()) as CursorUsageResponse;
-const plan =
+  const plan =
     data.membershipType === "free"
       ? "Free"
       : data.membershipType.charAt(0).toUpperCase() + data.membershipType.slice(1);
+
+  const email = await fetchCursorEmail(sessionToken);
+
+  // Unlimited plans (e.g. some Business/Ultra tiers) have no per-cycle cap, so
+  // a 0% bar conveys nothing. Show the plan badge alone — NextResetCard and
+  // ServiceDonutCard already render gracefully with windows: [].
+  if (data.isUnlimited) {
+    return {
+      name: "Cursor",
+      plan,
+      status: "ok",
+      email,
+      accountId: "",
+      windows: [],
+    };
+  }
 
   const start = formatDate(data.billingCycleStart);
   const end = formatDate(data.billingCycleEnd);
@@ -64,7 +85,6 @@ const plan =
   const autoPercent = Math.round(data.individualUsage?.plan?.autoPercentUsed ?? 0);
   const apiPercent = Math.round(data.individualUsage?.plan?.apiPercentUsed ?? 0);
 
-  const email = await fetchCursorEmail(sessionToken);
   return {
     name: "Cursor",
     plan,

--- a/src/lib/api/cursor.ts
+++ b/src/lib/api/cursor.ts
@@ -16,6 +16,17 @@ type CursorUsageResponse = {
       apiPercentUsed: number;
       totalPercentUsed: number;
     };
+    /**
+     * Pay-as-you-go usage block — analogous to Claude's `extra_usage`.
+     * Only meaningful when `enabled: true`. `used` and `limit` are dollars
+     * (matches what Cursor shows on the billing page).
+     */
+    onDemand?: {
+      enabled: boolean;
+      used: number;
+      limit: number | null;
+      remaining: number | null;
+    };
   };
 };
 
@@ -63,6 +74,16 @@ export async function fetchCursorUsage(sessionToken: string): Promise<ServiceDat
 
   const email = await fetchCursorEmail(sessionToken);
 
+  // Cursor's `onDemand` block is the direct analog of Claude's `extra_usage`:
+  // pay-as-you-go spend with an optional cap. Surface only when it's actually
+  // enabled (and a non-zero cap is set), so accounts that haven't opted into
+  // PAYG don't show a phantom "Extra usage $0 of $0" row.
+  const od = data.individualUsage?.onDemand;
+  const extraUsage =
+    od?.enabled && od.limit !== null && od.limit > 0
+      ? { usedDollars: od.used, monthlyLimitDollars: od.limit }
+      : undefined;
+
   // Unlimited plans (e.g. some Business/Ultra tiers) have no per-cycle cap, so
   // a 0% bar conveys nothing. Show the plan badge alone — NextResetCard and
   // ServiceDonutCard already render gracefully with windows: [].
@@ -74,6 +95,7 @@ export async function fetchCursorUsage(sessionToken: string): Promise<ServiceDat
       email,
       accountId: "",
       windows: [],
+      extraUsage,
     };
   }
 
@@ -95,5 +117,6 @@ export async function fetchCursorUsage(sessionToken: string): Promise<ServiceDat
       { label: `Auto · ${period}`, usedPercent: autoPercent, resetsAt },
       { label: `API · ${period}`, usedPercent: apiPercent, resetsAt },
     ],
+    extraUsage,
   };
 }


### PR DESCRIPTION
Four improvements from a usage-API survey across services. Closes [TOK-56](https://linear.app/mijeong-irene-ban/issue/TOK-56/show-claude-design-usage-in-usage-dashboard); the rest piggyback because they're tiny wins from the same investigation.

## Changes

### 1. Claude Design weekly usage (TOK-56)
Anthropic exposes a `seven_day_omelette` bucket on the Claude usage endpoint — `omelette` is the internal codename for Claude Design (verified by matching the 0% reading on this field against the Claude Design row in claude.ai → Settings → Usage). Wired up as "Weekly · Claude Design" alongside Sonnet / Opus.

### 2. ChatGPT "Go" plan label
Replaced the special-cased `plan_type === "plus"` mapping with a generic capitalization, so the new "Go" tier renders correctly (was lowercase) and any future tier name auto-formats.

### 3. Cursor unlimited plans
When `isUnlimited: true`, return empty windows so the card shows the plan badge alone instead of misleading 0% Auto/API bars. Both `ServiceDonutCard` and `NextResetCard` already render gracefully with `windows: []`.

### 4. Cursor pay-as-you-go (`onDemand`) parity
Cursor's `individualUsage.onDemand` block is the direct analog of Claude's `extra_usage` — same spent-vs-cap shape (`{ used, limit }`). Wired into the existing `extraUsage` field so it renders identically to Claude's "Extra usage" row, with the same color scaling and tray-warning thresholds. Only populated when `enabled: true` AND `limit > 0`, so non-PAYG accounts see no change.

## Why ChatGPT credits is NOT included

ChatGPT's `credits` block (`{ has_credits, balance, approx_local_messages, ... }`) exposes a **wallet/balance** ("$X remaining" or "~Y messages remaining"), not a **spent-vs-cap** amount. Forcing it into `ExtraUsage` would misrepresent the data. Worth its own follow-up ticket with a proper "Credits balance" UI (single row, no progress bar).

## What's still NOT in this PR (worth follow-up tickets)

- **ChatGPT credits** as described above.
- **ChatGPT** `rate_limit.limit_reached` (red badge), `spend_control.reached` (soft monthly cap).
- **ChatGPT** new `/wham/usage/daily-token-usage-breakdown` endpoint (per-product-surface breakdown — CLI/VSCode/Slack/Linear/etc.). Needs a UX design pass.
- **Claude** "Daily included routine runs" (1/15) — separate endpoint, not on `/usage`.
- **Claude** other observed buckets (`seven_day_oauth_apps`, `seven_day_cowork`, `omelette_promotional`, `tangelo`, `iguana_necktie`) — all `null` for the test account, UI mapping unconfirmed.
- **Cursor** absolute `used / limit` counts, `breakdown.bonus`, `teamUsage`.
- **Gemini** API survey not yet run.

## Verified
- TypeScript: `tsc --noEmit` clean.
- Frontend build: `vite build` clean.
- Tauri window render: needs eyeball test.

## Test plan
- [ ] `npm run tauri dev`; open the dashboard.
- [ ] **Claude:** confirm a fourth row "Weekly · Claude Design 0%" appears on the Claude card.
- [ ] **ChatGPT:** confirm the plan badge shows "Go" (capital G), not "go".
- [ ] **Cursor unlimited:** if you have access to an Unlimited account, confirm the card shows the plan badge but no usage bars.
- [ ] **Cursor PAYG:** if you enable on-demand billing in cursor.com settings with a non-zero monthly cap, confirm an "Extra usage $X.XX · of $Y.YY" row appears with a progress bar (matching Claude's layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)