### PR TITLE
fix(copilot): show "unlimited" row for Pro plans instead of blank card

### DIFF
--- a/src/lib/api/copilot.ts
+++ b/src/lib/api/copilot.ts
@@ -97,7 +97,11 @@ function buildRow(label: string, bucket: Bucket, resetsAt: string): UsageWindow 
       resetsAt,
     };
   }
-  return null;
+  // Pro/Pro+ unlimited case: GitHub omits limit, remaining, and percent
+  // entirely for buckets the plan covers without a cap. Render an empty bar
+  // labeled "Unlimited" so the row stays visible and the user can tell the
+  // plan covers it (vs. an empty card that looks like a fetch failure).
+  return { label: `${label} · unlimited`, usedPercent: 0, resetsAt };
 }
 
 export async function fetchCopilotUsage(sessionCookie: string): Promise<ServiceData> {


### PR DESCRIPTION
## Summary

Follow-up to [#35](https://github.com/mijeongireneban/uso.ai/pull/35). Caught while reviewing the Copilot integration after merge.

GitHub's `chat/entitlement` endpoint returns different shapes per plan tier:
- **Free** — bucket has `limit`, `remaining`, and `*Percentage` populated.
- **Pro / Pro+** — for unlimited buckets (chat, completions), GitHub omits `limit`, `remaining`, AND `*Percentage` entirely.

The `buildRow` helper had three branches: percent → use it; limit + remaining → compute; remaining only → show "N left". For a Pro account where all three quota fields are absent, every branch missed and `buildRow` returned `null`, dropping the row from the card. A Pro user would see an empty card indistinguishable from a fetch failure.

This PR adds a final fallback that renders an empty bar labeled `Code completions · unlimited` so the row stays visible and the user can tell the plan covers it.

## Test plan

- [ ] Free account (already-tested case) still renders `Code completions · N left` and `Chat messages` rows. No regression.
- [ ] Free account still hides the Premium requests row (limit === 0).
- [ ] Pro account renders all relevant rows; previously-missing buckets show `· unlimited` instead of disappearing.
- [ ] Card is never empty when the API responds with 200 + valid JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)