### PR TITLE
feat(notify): notify on service status transitions

### DIFF
--- a/src/lib/statusNotify.ts
+++ b/src/lib/statusNotify.ts
@@ -1,0 +1,105 @@
+import { notify } from "@/lib/notify";
+import type { OperationalStatus, ServiceStatus } from "@/types";
+
+type AccountStatus = {
+  accountId: string;
+  /** Display label, e.g. "Claude" or "Claude · Work". */
+  displayName: string;
+  status: ServiceStatus;
+};
+
+type OperationalSnapshot = {
+  serviceId: string;
+  serviceName: string;
+  status: OperationalStatus;
+};
+
+function describeAccountTransition(
+  displayName: string,
+  prev: ServiceStatus,
+  next: ServiceStatus,
+): { title: string; body: string } | null {
+  if ((prev === "expired" || prev === "error") && next === "ok") {
+    return {
+      title: `uso.ai · ${displayName} reconnected`,
+      body: `${displayName} is back. Usage tracking resumed.`,
+    };
+  }
+  if (prev !== "expired" && next === "expired") {
+    return {
+      title: `uso.ai · ${displayName} token expired`,
+      body: `Your ${displayName} session token has expired. Update it in Settings.`,
+    };
+  }
+  if (prev === "ok" && next === "error") {
+    return {
+      title: `uso.ai · ${displayName} fetch failed`,
+      body: `Couldn't load ${displayName} usage data. The provider's API may be unavailable.`,
+    };
+  }
+  return null;
+}
+
+function describeOperationalTransition(
+  serviceName: string,
+  prev: OperationalStatus,
+  next: OperationalStatus,
+): { title: string; body: string } | null {
+  if (prev === next) return null;
+  // Status pages occasionally drop to "unknown" on a single failed fetch — don't
+  // notify on those transitions; wait for a real state.
+  if (prev === "unknown" || next === "unknown") return null;
+
+  if (next === "outage") {
+    return {
+      title: `uso.ai · ${serviceName} outage`,
+      body: `${serviceName} is reporting an outage on its status page.`,
+    };
+  }
+  if (next === "degraded") {
+    return {
+      title: `uso.ai · ${serviceName} degraded`,
+      body: `${serviceName} is reporting degraded performance.`,
+    };
+  }
+  if (next === "operational" && (prev === "outage" || prev === "degraded")) {
+    return {
+      title: `uso.ai · ${serviceName} restored`,
+      body: `${serviceName} is back to all systems operational.`,
+    };
+  }
+  return null;
+}
+
+/**
+ * Fires a notification for each account whose ServiceStatus has transitioned
+ * since the last fetch. Accounts with no previous status (first sighting) are
+ * skipped to avoid notifying on app launch.
+ */
+export async function notifyAccountStatusChanges(
+  prev: Map<string, ServiceStatus>,
+  curr: AccountStatus[],
+): Promise<void> {
+  for (const acc of curr) {
+    const previous = prev.get(acc.accountId);
+    if (!previous) continue;
+    const message = describeAccountTransition(acc.displayName, previous, acc.status);
+    if (message) await notify(message.title, message.body);
+  }
+}
+
+/**
+ * Fires a notification for each service whose OperationalStatus has transitioned
+ * since the last fetch. Only configured services should be passed in.
+ */
+export async function notifyOperationalChanges(
+  prev: Map<string, OperationalStatus>,
+  curr: OperationalSnapshot[],
+): Promise<void> {
+  for (const svc of curr) {
+    const previous = prev.get(svc.serviceId);
+    if (!previous) continue;
+    const message = describeOperationalTransition(svc.serviceName, previous, svc.status);
+    if (message) await notify(message.title, message.body);
+  }
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -13,12 +13,13 @@ import { NextResetCard } from "@/components/dashboard/NextResetCard";
 import { ServiceDonutCard } from "@/components/dashboard/ServiceDonutCard";
 import { ServiceStatusPanel } from "@/components/dashboard/ServiceStatusPanel";
 import { notify, getJwtExpiry } from "@/lib/notify";
+import { notifyAccountStatusChanges, notifyOperationalChanges } from "@/lib/statusNotify";
 import { SERVICES } from "@/lib/services";
 import { saveHistorySnapshot } from "@/lib/history";
 import { maxUsagePercent, trayLevelFor, setTrayStatus } from "@/lib/tray";
 import History from "@/pages/History";
 import type { Account, CredentialsStore } from "@/lib/credentials";
-import type { ServiceData, ServiceStatusInfo } from "@/types";
+import type { OperationalStatus, ServiceData, ServiceStatus, ServiceStatusInfo } from "@/types";
 
 type Props = { onNavigateToSettings?: (serviceId?: string) => void };
 
@@ -113,6 +114,11 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
   // Tracks which (token prefix + threshold) combos have already fired a notification
   const notifiedRef = useRef<Set<string>>(new Set());
+  // Previous per-account auth/fetch status, keyed by accountId. Empty on first
+  // fetch — populated below — so we don't notify on app launch.
+  const previousAccountStatusRef = useRef<Map<string, ServiceStatus>>(new Map());
+  // Previous per-service operational (status page) status, keyed by serviceId.
+  const previousOperationalRef = useRef<Map<string, OperationalStatus>>(new Map());
 
   // Background expiry check — runs every minute, independently of the 5-min usage fetch
   const checkExpiry = useCallback(async () => {
@@ -199,14 +205,31 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
         }
       }
 
-      // Expired-token notifications
-      for (const s of results.filter((r) => r.status === "expired")) {
-        const nameWithLabel = s.label ? `${s.name} · ${s.label}` : s.name;
-        await notify(
-          `uso.ai · ${nameWithLabel} token expired`,
-          `Your ${nameWithLabel} session token has expired. Update it in Settings.`
-        );
-      }
+      // Status-change notifications — fire only on transitions, never on first
+      // fetch (refs are empty until populated below). Replaces an older loop
+      // that re-notified for every "expired" account on every 5-min fetch.
+      const accountSnapshots = results.map((r) => ({
+        accountId: r.accountId,
+        displayName: r.label ? `${r.name} · ${r.label}` : r.name,
+        status: r.status,
+      }));
+      const operationalSnapshots = Object.entries(operationalByService)
+        .map(([serviceId, info]) => {
+          const serviceName = SERVICES.find((s) => s.id === serviceId)?.name;
+          if (!serviceName) return null;
+          return { serviceId, serviceName, status: info.status };
+        })
+        .filter((s): s is { serviceId: string; serviceName: string; status: OperationalStatus } => s !== null);
+
+      await notifyAccountStatusChanges(previousAccountStatusRef.current, accountSnapshots);
+      await notifyOperationalChanges(previousOperationalRef.current, operationalSnapshots);
+
+      previousAccountStatusRef.current = new Map(
+        accountSnapshots.map((a) => [a.accountId, a.status])
+      );
+      previousOperationalRef.current = new Map(
+        operationalSnapshots.map((s) => [s.serviceId, s.status])
+      );
 
       setServices(results.filter((r): r is ServiceData => r !== null));
       setLastUpdated(new Date());


### PR DESCRIPTION
## Summary

Adds desktop notifications when a service's status changes between fetches — both auth/fetch state per account and operational state per provider.

- **Per-account `ServiceStatus`**: ok ↔ expired/error transitions
  - `ok → expired` → "Claude · Work token expired"
  - `ok → error` → "Cursor fetch failed"
  - `expired/error → ok` → "Claude · Work reconnected"
- **Per-service `OperationalStatus`** (status-page changes):
  - `operational → degraded` / `→ outage`
  - `outage/degraded → operational` → "ChatGPT restored"
  - Skips noisy transitions through `unknown`

## Implementation

- New [src/lib/statusNotify.ts](src/lib/statusNotify.ts) — pure transition helpers + descriptive messages
- [src/pages/Dashboard.tsx](src/pages/Dashboard.tsx) — two refs hold the previous status snapshots; on each fetch, the helpers fire notifications only on real transitions
- Refs start empty so no notifications fire on app launch (only on subsequent transitions)

## Bug fix included

Replaces the previous every-fetch `expired` notification loop, which re-fired for every expired account every 5 min while the token stayed expired. Now expired-token notifications fire **once** on transition.

The 30-min and 3-min ChatGPT JWT pre-expiry warnings are unchanged.

## Test plan

- [ ] Launch app — no spurious notifications on first fetch
- [ ] Invalidate a Claude session → see "Claude token expired" exactly once (not every 5 min)
- [ ] Re-add valid Claude credentials → see "Claude reconnected"
- [ ] Manually trigger a fetch error (kill network) → see "fetch failed" notification once

🤖 Generated with [Claude Code](https://claude.com/claude-code)