### PR TITLE
feat(tray): exclude extra usage from menu bar warning (#40)

### DIFF
--- a/src/lib/preferences.ts
+++ b/src/lib/preferences.ts
@@ -10,7 +10,16 @@ export type Preferences = {
    * is a user override and always wins.
    */
   geminiModelVisibility?: Record<string, boolean>;
+  /**
+   * Per-service flag to exclude that service's "extra usage" (metered top-up
+   * spend beyond the plan limit) from the menu bar tray icon color. Keyed by
+   * service id (e.g. "claude", "cursor"). A missing or false entry means
+   * extra usage IS counted toward the tray warning level.
+   */
+  excludeExtraUsageFromTray?: Record<string, boolean>;
 };
+
+export const PREFERENCES_CHANGED_EVENT = "uso:preferences-changed";
 
 const FILE = "preferences.json";
 const KEY = "preferences";
@@ -34,4 +43,21 @@ export async function setGeminiModelVisible(modelId: string, visible: boolean): 
   };
   await savePreferences(next);
   return next;
+}
+
+export async function setExcludeExtraUsageFromTray(serviceId: string, exclude: boolean): Promise<Preferences> {
+  const prefs = await loadPreferences();
+  const next: Preferences = {
+    ...prefs,
+    excludeExtraUsageFromTray: { ...(prefs.excludeExtraUsageFromTray ?? {}), [serviceId]: exclude },
+  };
+  await savePreferences(next);
+  window.dispatchEvent(new Event(PREFERENCES_CHANGED_EVENT));
+  return next;
+}
+
+/** Set of service ids whose extra usage should be excluded from the tray icon. */
+export function extraUsageTrayExclusions(prefs: Preferences): Set<string> {
+  const map = prefs.excludeExtraUsageFromTray ?? {};
+  return new Set(Object.entries(map).filter(([, v]) => v).map(([k]) => k));
 }

--- a/src/lib/tray.ts
+++ b/src/lib/tray.ts
@@ -1,5 +1,6 @@
 import { invoke } from "@tauri-apps/api/core";
 import type { ServiceData } from "@/types";
+import { getServiceByName } from "./services";
 
 export type TrayLevel = "normal" | "warning" | "critical";
 
@@ -14,14 +15,24 @@ const CRITICAL_THRESHOLD = 80;
  * Return the highest usage percentage observed across all "ok" services,
  * covering both per-window usedPercent and metered top-up spend
  * (extraUsage). Returns 0 when there's nothing to report.
+ *
+ * `excludeExtraForIds` lets the caller opt specific services out of
+ * having their extraUsage count toward the tray level — e.g. when a user
+ * doesn't want Claude's metered top-up credit to flip the menu bar icon
+ * to yellow/red (see preferences.excludeExtraUsageFromTray).
  */
-export function maxUsagePercent(services: ServiceData[]): number {
+export function maxUsagePercent(
+  services: ServiceData[],
+  excludeExtraForIds: ReadonlySet<string> = new Set()
+): number {
   let max = 0;
   for (const service of services) {
     if (service.status !== "ok") continue;
     for (const window of service.windows) {
       if (window.usedPercent > max) max = window.usedPercent;
     }
+    const serviceId = getServiceByName(service.name)?.id;
+    if (serviceId && excludeExtraForIds.has(serviceId)) continue;
     const extra = service.extraUsage;
     if (extra && extra.monthlyLimitDollars > 0) {
       const pct = (extra.usedDollars / extra.monthlyLimitDollars) * 100;

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -17,6 +17,11 @@ import { notifyAccountStatusChanges, notifyOperationalChanges } from "@/lib/stat
 import { SERVICES } from "@/lib/services";
 import { saveHistorySnapshot } from "@/lib/history";
 import { maxUsagePercent, trayLevelFor, setTrayStatus } from "@/lib/tray";
+import {
+  loadPreferences,
+  extraUsageTrayExclusions,
+  PREFERENCES_CHANGED_EVENT,
+} from "@/lib/preferences";
 import History from "@/pages/History";
 import type { Account, CredentialsStore } from "@/lib/credentials";
 import type { OperationalStatus, ServiceData, ServiceStatus, ServiceStatusInfo } from "@/types";
@@ -112,6 +117,7 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
   const [loading, setLoading] = useState(true);
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [lastUpdated, setLastUpdated] = useState<Date | null>(null);
+  const [extraUsageTrayExcludes, setExtraUsageTrayExcludes] = useState<Set<string>>(new Set());
   // Tracks which (token prefix + threshold) combos have already fired a notification
   const notifiedRef = useRef<Set<string>>(new Set());
   // Previous per-account auth/fetch status, keyed by accountId. Empty on first
@@ -262,6 +268,25 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
     };
   }, [fetchAll, checkExpiry]);
 
+  // Pick up the user's per-service "exclude extra usage from tray" preference
+  // and refresh it when Settings dispatches a change event so the tray reflects
+  // the toggle without waiting for the next 5-minute fetch.
+  useEffect(() => {
+    let cancelled = false;
+    const refresh = () => {
+      loadPreferences().then((p) => {
+        if (cancelled) return;
+        setExtraUsageTrayExcludes(extraUsageTrayExclusions(p));
+      });
+    };
+    refresh();
+    window.addEventListener(PREFERENCES_CHANGED_EVENT, refresh);
+    return () => {
+      cancelled = true;
+      window.removeEventListener(PREFERENCES_CHANGED_EVENT, refresh);
+    };
+  }, []);
+
   // Mirror the highest observed usage % onto the menu bar tray icon so the
   // user can glance at the status bar and see whether any account is
   // nearing a limit without opening the dashboard (TOK-53). Runs on every
@@ -269,9 +294,9 @@ export default function Dashboard({ onNavigateToSettings }: Props) {
   // the neutral template icon.
   useEffect(() => {
     if (loading) return;
-    const level = trayLevelFor(maxUsagePercent(services));
+    const level = trayLevelFor(maxUsagePercent(services, extraUsageTrayExcludes));
     setTrayStatus(level);
-  }, [services, loading]);
+  }, [services, loading, extraUsageTrayExcludes]);
 
   return (
     <div className="space-y-3">

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -13,7 +13,11 @@ import { fetchChatGPTUsage } from "@/lib/api/chatgpt";
 import { fetchCursorUsage } from "@/lib/api/cursor";
 import { fetchCopilotUsage } from "@/lib/api/copilot";
 import { fetchGeminiModels, GEMINI_FREE_TIER } from "@/lib/api/gemini";
-import { setGeminiModelVisible } from "@/lib/preferences";
+import {
+  loadPreferences,
+  setGeminiModelVisible,
+  setExcludeExtraUsageFromTray,
+} from "@/lib/preferences";
 import { exists, BaseDirectory } from "@tauri-apps/plugin-fs";
 import type { Account, CredentialsStore } from "@/lib/credentials";
 import type { GeminiModelInfo } from "@/lib/api/gemini";
@@ -83,6 +87,18 @@ export default function Settings({ tab, onTabChange }: Props) {
   const [geminiEmail, setGeminiEmail] = useState<string | undefined>(undefined);
   const [geminiTier, setGeminiTier] = useState<string>("");
   const [geminiModels, setGeminiModels] = useState<GeminiModelInfo[]>([]);
+  const [excludeExtraFromTray, setExcludeExtraFromTrayState] = useState<Record<string, boolean>>({});
+
+  useEffect(() => {
+    loadPreferences().then((p) => {
+      setExcludeExtraFromTrayState(p.excludeExtraUsageFromTray ?? {});
+    });
+  }, []);
+
+  async function toggleExcludeExtraFromTray(serviceId: string, exclude: boolean) {
+    setExcludeExtraFromTrayState((prev) => ({ ...prev, [serviceId]: exclude }));
+    await setExcludeExtraUsageFromTray(serviceId, exclude);
+  }
 
   useEffect(() => {
     loadCredentials().then((creds) => {
@@ -348,6 +364,35 @@ export default function Settings({ tab, onTabChange }: Props) {
               >
                 + Add account
               </Button>
+
+              {/* Extra-usage tray toggle: Claude and Cursor surface metered
+                  top-up spend ("extra usage") that can fill faster than the
+                  plan window. Let the user opt that signal out of the menu
+                  bar color so the tray only reflects plan usage. */}
+              {(service.id === "claude" || service.id === "cursor") && (
+                <Card>
+                  <CardContent className="px-5 py-4">
+                    <label className="flex items-start gap-2.5 cursor-pointer select-none">
+                      <input
+                        type="checkbox"
+                        checked={!(excludeExtraFromTray[service.id] ?? false)}
+                        onChange={(e) => toggleExcludeExtraFromTray(service.id, !e.target.checked)}
+                        className="h-3.5 w-3.5 mt-0.5 rounded border-border accent-primary shrink-0"
+                      />
+                      <span className="space-y-1">
+                        <span className="text-xs font-medium block">
+                          Count extra usage toward menu bar warning
+                        </span>
+                        <span className="text-xs text-muted-foreground leading-relaxed block">
+                          When off, the tray icon stays neutral even if {service.name}'s
+                          metered top-up credit is high. Plan usage still
+                          affects the tray color.
+                        </span>
+                      </span>
+                    </label>
+                  </CardContent>
+                </Card>
+              )}
             </TabsContent>
           );
         })}


### PR DESCRIPTION
## Summary
- Adds a per-service preference so a service's metered top-up spend ("extra usage") can be excluded from the tray icon color.
- New toggle in **Settings → Claude** (and **Cursor**, which has the same metered-overage concept): *"Count extra usage toward menu bar warning"*. Default = on, matching today's behavior.
- Plan-window usage still drives the tray as before; the Claude/Cursor dashboard cards still show the extra-usage bar.

## How it works
- `Preferences.excludeExtraUsageFromTray: Record<string, boolean>` is persisted in `preferences.json` via `tauri-plugin-store`.
- `maxUsagePercent(services, excludeIds)` skips `extraUsage` for excluded service ids.
- Settings dispatches a `uso:preferences-changed` window event on toggle; Dashboard listens and re-applies the tray level immediately (no 5-min wait).

Closes #40

## Test plan
- [ ] Run `npm run tauri dev`, configure a Claude account whose extra-usage % exceeds 60.
- [ ] Confirm the tray icon is the warning/critical variant initially.
- [ ] In **Settings → Claude**, uncheck *"Count extra usage toward menu bar warning"*.
- [ ] Tray icon flips back to the normal template variant within ~1s.
- [ ] Re-check the box → tray color returns.
- [ ] Repeat for **Cursor**.
- [ ] Quit and relaunch the app — preference persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)