### PR TITLE
fix(claude): treat extra usage used_credits as cents

### DIFF
--- a/src/lib/api/claude.ts
+++ b/src/lib/api/claude.ts
@@ -18,8 +18,8 @@ type ClaudeUsageResponse = {
    */
   seven_day_omelette?: UsageBucket;
   /**
-   * Pay-as-you-go spend. `monthly_limit` is returned in **cents**,
-   * `used_credits` is returned in **dollars** (float).
+   * Pay-as-you-go spend. Both `monthly_limit` and `used_credits` are returned
+   * in **cents** — divide by 100 to get dollars.
    */
   extra_usage?: {
     is_enabled: boolean;
@@ -106,11 +106,10 @@ export async function fetchClaudeUsage(
     });
   }
 
-  // Pay-as-you-go: monthly_limit is cents, used_credits is dollars.
   const extraUsage =
     data.extra_usage?.is_enabled && data.extra_usage.monthly_limit > 0
       ? {
-          usedDollars: data.extra_usage.used_credits,
+          usedDollars: data.extra_usage.used_credits / 100,
           monthlyLimitDollars: data.extra_usage.monthly_limit / 100,
         }
       : undefined;


### PR DESCRIPTION
## Summary
- Claude's `/usage` endpoint returns both `monthly_limit` and `used_credits` in cents, but `used_credits` was being passed through as dollars — so $1.41 of pay-as-you-go spend displayed as **$141.00** on the dashboard.
- Divide `used_credits` by 100 to match the limit, and correct the stale comment / JSDoc that incorrectly described the unit.

Fixes #41

## Test plan
- [ ] Connect a Claude account with non-zero pay-as-you-go spend and confirm the "Extra usage" row shows the dollar amount that matches claude.ai → Settings → Usage
- [ ] Verify accounts with `extra_usage.is_enabled === false` or `monthly_limit === 0` still hide the Extra usage row
- [ ] Verify the tray warning level still computes correctly when extra usage is included

🤖 Generated with [Claude Code](https://claude.com/claude-code)