### PR TITLE
fix(api): stop misreading transient 403 as expired token

### DIFF
--- a/src/lib/api/chatgpt.ts
+++ b/src/lib/api/chatgpt.ts
@@ -1,4 +1,5 @@
 import { fetch } from "@tauri-apps/plugin-http";
+import { fetchWithRetry } from "@/lib/api/fetch";
 import type { ServiceData } from "@/types";
 import { calendarDayDiff } from "./utils";
 
@@ -60,14 +61,17 @@ async function fetchChatGPTEmail(bearerToken: string): Promise<string | undefine
 }
 
 export async function fetchChatGPTUsage(bearerToken: string): Promise<ServiceData> {
-  const res = await fetch("https://chatgpt.com/backend-api/wham/usage", {
+  const res = await fetchWithRetry("https://chatgpt.com/backend-api/wham/usage", {
     method: "GET",
     headers: {
       Authorization: `Bearer ${bearerToken}`,
     },
   });
 
-  if (res.status === 401 || res.status === 403) {
+  // 401 = real auth failure (Bearer JWT genuinely expired). 403 from
+  // Cloudflare is usually transient — surface as "error" so it self-heals on
+  // the next 5-min poll instead of showing a false "Token expired".
+  if (res.status === 401) {
     return { name: "ChatGPT (Codex)", plan: "Plus", status: "expired", windows: [], accountId: "" };
   }
   if (!res.ok) {

--- a/src/lib/api/claude.ts
+++ b/src/lib/api/claude.ts
@@ -1,4 +1,5 @@
 import { fetch } from "@tauri-apps/plugin-http";
+import { fetchWithRetry } from "@/lib/api/fetch";
 import { formatResetTime } from "@/lib/api/utils";
 import type { ServiceData } from "@/types";
 
@@ -50,7 +51,7 @@ export async function fetchClaudeUsage(
   orgId: string,
   sessionKey: string
 ): Promise<ServiceData> {
-  const res = await fetch(
+  const res = await fetchWithRetry(
     `https://claude.ai/api/organizations/${orgId}/usage`,
     {
       method: "GET",
@@ -60,8 +61,11 @@ export async function fetchClaudeUsage(
     }
   );
 
-  if (res.status === 401 || res.status === 403) {
-    console.warn(`[claude] usage fetch returned ${res.status} — credential rejected by claude.ai`);
+  // 401 = real auth failure. 403 from Cloudflare's bot heuristic is usually
+  // transient and recovers on the next poll, so don't burn the user with a
+  // scary "Token expired" CTA for what's actually a flickering edge.
+  if (res.status === 401) {
+    console.warn("[claude] usage fetch returned 401 — credential rejected by claude.ai");
     return { name: "Claude", plan: "Pro", status: "expired", windows: [], accountId: "" };
   }
   if (!res.ok) {

--- a/src/lib/api/copilot.ts
+++ b/src/lib/api/copilot.ts
@@ -1,4 +1,4 @@
-import { fetch } from "@tauri-apps/plugin-http";
+import { fetchWithRetry } from "@/lib/api/fetch";
 import type { ServiceData, UsageWindow } from "@/types";
 import { calendarDayDiff } from "./utils";
 
@@ -105,7 +105,7 @@ function buildRow(label: string, bucket: Bucket, resetsAt: string): UsageWindow 
 }
 
 export async function fetchCopilotUsage(sessionCookie: string): Promise<ServiceData> {
-  const res = await fetch(ENTITLEMENT_URL, {
+  const res = await fetchWithRetry(ENTITLEMENT_URL, {
     method: "GET",
     headers: {
       accept: "application/json",
@@ -113,7 +113,10 @@ export async function fetchCopilotUsage(sessionCookie: string): Promise<ServiceD
     },
   });
 
-  if (res.status === 401 || res.status === 403) {
+  // 401 = real auth failure. 403 from GitHub's abuse heuristic is usually
+  // transient — surface as "error" so the next poll self-heals instead of
+  // flagging the cookie as expired.
+  if (res.status === 401) {
     return { name: "GitHub Copilot", plan: "Free", status: "expired", windows: [], accountId: "" };
   }
   if (!res.ok) {

--- a/src/lib/api/cursor.ts
+++ b/src/lib/api/cursor.ts
@@ -1,4 +1,5 @@
 import { fetch } from "@tauri-apps/plugin-http";
+import { fetchWithRetry } from "@/lib/api/fetch";
 import type { ServiceData } from "@/types";
 
 type CursorUsageResponse = {
@@ -52,14 +53,17 @@ async function fetchCursorEmail(sessionToken: string): Promise<string | undefine
 }
 
 export async function fetchCursorUsage(sessionToken: string): Promise<ServiceData> {
-  const res = await fetch("https://cursor.com/api/usage-summary", {
+  const res = await fetchWithRetry("https://cursor.com/api/usage-summary", {
     method: "GET",
     headers: {
       Cookie: `WorkosCursorSessionToken=${sessionToken}`,
     },
   });
 
-  if (res.status === 401 || res.status === 403) {
+  // 401 = real auth failure. 403 from Cloudflare is usually transient — let
+  // it surface as "error" so the next 5-min poll self-recovers rather than
+  // showing a false "Token expired" card.
+  if (res.status === 401) {
     return { name: "Cursor", plan: "Free", status: "expired", windows: [], accountId: "" };
   }
   if (!res.ok) {

--- a/src/lib/api/fetch.ts
+++ b/src/lib/api/fetch.ts
@@ -1,0 +1,69 @@
+import { fetch } from "@tauri-apps/plugin-http";
+
+/**
+ * Wraps `@tauri-apps/plugin-http`'s fetch with a single retry on transient
+ * failures and a browser-shaped header set. Tauri's HTTP client otherwise
+ * sends a bare `Cookie:` with no User-Agent / Accept / Accept-Language, which
+ * Cloudflare-fronted providers (Claude, ChatGPT, Cursor, GitHub) routinely
+ * flag as bot traffic and answer with a 403 — even though the credential is
+ * valid. Without retry, a single transient 403 surfaces as a persistent
+ * "Token expired" card until the next 5-min poll.
+ *
+ * Retry only fires on statuses that are typically transient (403, 408, 429,
+ * 5xx) or on a thrown network error. 401 is NOT retried because that almost
+ * always means the credential really is invalid.
+ */
+
+type FetchInit = Parameters<typeof fetch>[1];
+
+type RetryOptions = {
+  retries?: number;
+  retryDelayMs?: number;
+};
+
+const RETRYABLE_STATUS = new Set([403, 408, 429, 500, 502, 503, 504]);
+
+const DEFAULT_BROWSER_HEADERS: Record<string, string> = {
+  "User-Agent":
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/130.0.0.0 Safari/537.36",
+  Accept: "application/json, text/plain, */*",
+  "Accept-Language": "en-US,en;q=0.9",
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export async function fetchWithRetry(
+  input: string,
+  init: FetchInit = {},
+  opts: RetryOptions = {}
+): Promise<Response> {
+  const { retries = 1, retryDelayMs = 900 } = opts;
+  const callerHeaders = (init?.headers ?? {}) as Record<string, string>;
+  const merged: FetchInit = {
+    ...init,
+    headers: { ...DEFAULT_BROWSER_HEADERS, ...callerHeaders },
+  };
+
+  let lastErr: unknown;
+  for (let attempt = 0; attempt <= retries; attempt++) {
+    try {
+      const res = await fetch(input, merged);
+      if (res.ok) return res;
+      if (attempt < retries && RETRYABLE_STATUS.has(res.status)) {
+        await sleep(retryDelayMs);
+        continue;
+      }
+      return res;
+    } catch (err) {
+      lastErr = err;
+      if (attempt < retries) {
+        await sleep(retryDelayMs);
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastErr ?? new Error("fetchWithRetry exhausted retries");
+}


### PR DESCRIPTION
## Summary
- Claude (and the same bug class in ChatGPT/Cursor/Copilot) showed "Token expired" even when the cookie was valid — re-saving the unchanged credential in Settings always validated fine. Root cause: `tauri-plugin-http` sends a bare `Cookie:` header with no User-Agent / Accept / Sec-Fetch fields, and each provider's edge (Cloudflare for Claude/ChatGPT/Cursor, GitHub's abuse heuristic for Copilot) intermittently responded **403** to that fingerprint. Our code collapsed 401 and 403 into `status: "expired"`, so one flickery edge request would paint a scary "Token expired" + "Fix" CTA until the next 5-min poll.
- New `fetchWithRetry` helper injects browser-shaped headers (UA, Accept, Accept-Language) and retries once on 403/408/429/5xx/network error (~900ms delay). 401 is never retried — it's almost always real auth failure.
- All four provider usage fetches route through `fetchWithRetry`. **401 → `expired`** (real), **403 → `error`** (transient, self-heals on next poll).

## Test plan
- [ ] `npm run build` passes (verified locally — tsc + Vite clean)
- [ ] Run `npm run tauri dev`, leave the menu bar app open for ~30+ minutes through several 5-min poll cycles, confirm no false "Token expired" cards appear on cards that previously flickered
- [ ] Settings → save unchanged Claude credentials still validates OK (regression check on the path users were using as a workaround)
- [ ] Intentionally corrupt the Claude `sessionKey` (e.g. trim a char), refresh: card correctly shows "Token expired" with "Fix" CTA (401 path still works)
- [ ] Console: on a transient 403 you should see `[claude] usage fetch failed with status 403` (not the "credential rejected" warning, which is now 401-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)